### PR TITLE
Allow toXML to be called sync, respect conventions

### DIFF
--- a/lib/sitemap.js
+++ b/lib/sitemap.js
@@ -218,9 +218,16 @@ Sitemap.prototype.del = function (url) {
  *  @param {Function}     callback  Callback function with one argument — xml
  */
 Sitemap.prototype.toXML = function (callback) {
+  if (typeof callback === 'undefined') {
+    return this.toString();
+  }
   var self = this;
   process.nextTick( function () {
-    callback( self.toString() );
+    if (callback.length === 1) {
+      callback( self.toString() );
+    } else {
+      callback( null, self.toString() );
+    }
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "git://github.com/ekalinin/sitemap.js.git",
   "author": "Eugene Kalinin <e.v.kalinin@gmail.com>",
   "devDependencies": {
-    "expresso": "0.8.1"
+    "expresso": "^0.9.2"
   },
   "main": "index",
   "scripts": {

--- a/tests/sitemap.test.js
+++ b/tests/sitemap.test.js
@@ -102,6 +102,56 @@ module.exports = {
                 '</url>\n'+
               '</urlset>');
   },
+  'simple sitemap toXML async with one callback argument': function(beforeExit, assert) {
+    var url = 'http://ya.ru';
+    var ssp = new sm.Sitemap();
+    ssp.add(url);
+
+    ssp.toXML(function(xml) {
+      assert.eql(xml,
+                '<?xml version="1.0" encoding="UTF-8"?>\n'+
+                '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'+
+                  '<url> '+
+                      '<loc>http://ya.ru</loc> '+
+                      '<changefreq>weekly</changefreq> '+
+                      '<priority>0.5</priority> '+
+                  '</url>\n'+
+                '</urlset>');
+    });
+  },
+  'simple sitemap toXML async with two callback arguments': function(beforeExit, assert) {
+    var url = 'http://ya.ru';
+    var ssp = new sm.Sitemap();
+    ssp.add(url);
+
+    ssp.toXML(function(err, xml) {
+      assert.isNull(err);
+      assert.eql(xml,
+                '<?xml version="1.0" encoding="UTF-8"?>\n'+
+                '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'+
+                  '<url> '+
+                      '<loc>http://ya.ru</loc> '+
+                      '<changefreq>weekly</changefreq> '+
+                      '<priority>0.5</priority> '+
+                  '</url>\n'+
+                '</urlset>');
+    });
+  },
+  'simple sitemap toXML sync': function() {
+    var url = 'http://ya.ru';
+    var ssp = new sm.Sitemap();
+    ssp.add(url);
+
+    assert.eql(ssp.toXML(),
+              '<?xml version="1.0" encoding="UTF-8"?>\n'+
+              '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'+
+                '<url> '+
+                    '<loc>http://ya.ru</loc> '+
+                    '<changefreq>weekly</changefreq> '+
+                    '<priority>0.5</priority> '+
+                '</url>\n'+
+              '</urlset>');
+  },
   'simple sitemap index': function() {
     var url1 = 'http://ya.ru';
     var url2 = 'http://ya2.ru';


### PR DESCRIPTION
The toXML method currently takes a callback with only one argument, the xml. Node's convention demands that the callback take an error, and then the result.

All toXML is doing is calling `toString`, so there is no need for the method to be async, it wrongly implies that there is a difference between the sync and async version. But at this moment removing this method would break existing users.

This PR makes toXML optionally sync, if no callback is passed on. If one is passed, it verifies if the callback expects one or two arguments, effectively emulating the previous behavior, while still allowing correct node convetions with error and result being passed to the callback.

Expresso was also updated to better allow for async tests.
