### PR TITLE
Bugfix: lPad on negative number should ignore leading '-'

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -39,10 +39,22 @@ exports.htmlEscape = function (text) {
  */
 exports.lpad = function (n, len, chr) {
   var res = n.toString()
-    , chr = chr || '0';
+    , chr = chr || '0'
+    , leading = (res.substr(0, 1) === '-') ? true : false;
+
+  //If left side of string is a minus sign (negative number), we want to ignore that in the padding process
+  if(leading){
+    res = res.substr(1); //cut-off the leading '-'
+  }
+
   while (res.length < len) {
     res = chr + res;
   }
+
+  if(leading){ //If we initially cutoff the leading '-', we add it again here
+    res = '-' + res;
+  }
+
   return res;
 }
 


### PR DESCRIPTION
When timezone is ie. negative 2 hours, the lPad function would pad this number to "-2:00", but it should be "-02:00" to pass validation tests, such as in Google Webmaster Tools

Fixed the lPad util function to ignore the leading '-' in case of a negative number