### PR TITLE
new feature to allow multiple images to be passed & fix to issue #27

### DIFF
--- a/lib/sitemap.js
+++ b/lib/sitemap.js
@@ -119,8 +119,19 @@ SitemapItem.prototype.toString = function () {
     p = props[ps];
 
     if(this[p] && p == 'img') {
-      xml = xml.replace('{' + p + '}',
-          '<image:image><image:loc>'+this[p]+'</image:loc></image:image>');
+      // Image handling
+      imagexml = '<image:image><image:loc>'+this[p]+'</image:loc></image:image>';
+      if(typeof(this[p])=='object'){
+        if(this[p]&&this[p].length>0){
+          imagexml = '';
+          this[p].forEach(function(image){
+            imagexml += '<image:image><image:loc>'+image+'</image:loc></image:image>';
+          });
+        }
+      }
+
+      xml = xml.replace('{' + p + '}',imagexml);
+
     } else if (this[p]) {
       xml = xml.replace('{'+p+'}',
                   '<'+p+'>'+this[p]+'</'+p+'>');

--- a/lib/sitemap.js
+++ b/lib/sitemap.js
@@ -7,7 +7,8 @@
 var ut = require('./utils')
   , err = require('./errors')
   , urlparser = require('url')
-  , fs = require('fs');
+  , fs = require('fs')
+  , _ = require('underscore');
 
 exports.Sitemap = Sitemap;
 exports.SitemapItem = SitemapItem;
@@ -161,7 +162,10 @@ function Sitemap(urls, hostname, cacheTime) {
   this.hostname = hostname;
 
   // URL list for sitemap
-  this.urls = urls || [];
+  this.urls = [];
+  // Make copy of object
+  if(urls) _.extend(this.urls,urls);
+
   if ( !(this.urls instanceof Array) ) {
     this.urls = [ this.urls ]
   }

--- a/package.json
+++ b/package.json
@@ -2,11 +2,14 @@
   "name": "sitemap",
   "version": "0.8.1",
   "description": "Sitemap-generating framework",
-  "keywords": ["sitemap", "sitemap.xml"],
+  "keywords": [
+    "sitemap",
+    "sitemap.xml"
+  ],
   "repository": "git://github.com/ekalinin/sitemap.js.git",
   "author": "Eugene Kalinin <e.v.kalinin@gmail.com>",
   "dependencies": {
-    "underscore": "1.7.0"
+    "underscore": "^1.7.0"
   },
   "devDependencies": {
     "expresso": "^0.9.2"


### PR DESCRIPTION
This fix allows for multiple images to be passed.

Eg: 
```javascript
{ url: '/page-4/',   img: ['http://urlTest.com','http://urlTest2.com']}
```

This will generate:
```javascript
<image:image><image:loc>http://urlTest.com</image:loc></image:image>
<image:image><image:loc>http://urlTest2.com</image:loc></image:image>
```