### PR TITLE
Updated lib/sitemap.js

### DIFF
--- a/lib/sitemap.js
+++ b/lib/sitemap.js
@@ -22,10 +22,11 @@ exports.createSitemapIndex = createSitemapIndex;
  * @param   {String}        conf.hostname
  * @param   {String|Array}  conf.urls
  * @param   {Number}        conf.cacheTime
+ * @param   {String}        conf.xslUrl
  * @return  {Sitemap}
  */
 function createSitemap(conf) {
-  return new Sitemap(conf.urls, conf.hostname, conf.cacheTime);
+  return new Sitemap(conf.urls, conf.hostname, conf.cacheTime, conf.xslUrl);
 }
 
 function safeUrl(conf) {
@@ -160,10 +161,10 @@ SitemapItem.prototype.toString = function () {
  * Sitemap constructor
  * @param {String|Array}  urls
  * @param {String}        hostname    optional
- * @param {Number}        cacheTime   optional in milliseconds;
- *                                    0 - cache disabled
+ * @param {Number}        cacheTime   optional in milliseconds; 0 - cache disabled
+ * @param {String}        xslUrl			optional
  */
-function Sitemap(urls, hostname, cacheTime) {
+function Sitemap(urls, hostname, cacheTime, xslUrl) {
 
   // This limit is defined by Google. See:
   // http://sitemaps.org/protocol.php#index
@@ -181,6 +182,8 @@ function Sitemap(urls, hostname, cacheTime) {
   // sitemap cache
   this.cacheResetPeriod = cacheTime || 0;
   this.cache = '';
+  
+  this.xslUrl = xslUrl;
 }
 
 /**
@@ -283,14 +286,18 @@ Sitemap.prototype.toString = function () {
               'xmlns:xhtml="http://www.w3.org/1999/xhtml" ' +
               'xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">'
             ];
+            
+  if(self.xslUrl) {
+		xml.splice(1, 0, '<?xml-stylesheet type="text/xsl" href="' + self.xslUrl + '"?>');
+	}
 
-  if (this.isCacheValid()) {
-    return this.cache;
+  if (self.isCacheValid()) {
+    return self.cache;
   }
 
   // TODO: if size > limit: create sitemapindex
 
-  this.urls.forEach( function (elem, index) {
+  self.urls.forEach( function (elem, index) {
     // SitemapItem
     var smi = elem;
 
@@ -316,11 +323,11 @@ Sitemap.prototype.toString = function () {
   // close xml
   xml.push('</urlset>');
 
-  return this.setCache(xml.join('\n'));
+  return self.setCache(xml.join('\n'));
 }
 
 /**
- * Shortcut for `new Sitemap (...)`.
+ * Shortcut for `new SitemapIndex (...)`.
  *
  * @param   {Object}        conf
  * @param   {String|Array}  conf.urls
@@ -329,6 +336,7 @@ Sitemap.prototype.toString = function () {
  * @param   {Number}        conf.cacheTime
  * @param   {String}        conf.sitemapName
  * @param   {Number}        conf.sitemapSize
+ * @param   {String}        conf.xslUrl
  * @return  {SitemapIndex}
  */
 function createSitemapIndex(conf) {
@@ -338,6 +346,7 @@ function createSitemapIndex(conf) {
                             conf.cacheTime,
                             conf.sitemapName,
                             conf.sitemapSize,
+                            conf.xslUrl,
                             conf.callback);
 }
 
@@ -347,10 +356,11 @@ function createSitemapIndex(conf) {
  * @param {String}        targetFolder
  * @param {String}        hostname      optional
  * @param {Number}        cacheTime     optional in milliseconds
- * @param {String}        sitemapName   optionnal
- * @param {Number}        sitemapSize   optionnal
+ * @param {String}        sitemapName   optional
+ * @param {Number}        sitemapSize   optional
+ * @param {Number}        xslUrl				optional
  */
-function SitemapIndex(urls, targetFolder, hostname, cacheTime, sitemapName, sitemapSize, callback) {
+function SitemapIndex(urls, targetFolder, hostname, cacheTime, sitemapName, sitemapSize, xslUrl, callback) {
 
   var self = this;
 
@@ -369,6 +379,8 @@ function SitemapIndex(urls, targetFolder, hostname, cacheTime, sitemapName, site
   // This limit is defined by Google. See:
   // http://sitemaps.org/protocol.php#index
   self.sitemapSize = sitemapSize;
+  
+  self.xslUrl = xslUrl;
 
   self.sitemapId = 0;
 
@@ -384,8 +396,8 @@ function SitemapIndex(urls, targetFolder, hostname, cacheTime, sitemapName, site
 
   // URL list for sitemap
   self.urls = urls || [];
-  if ( !(this.urls instanceof Array) ) {
-    this.urls = [ this.urls ]
+  if ( !(self.urls instanceof Array) ) {
+    self.urls = [ self.urls ]
   }
 
   self.chunks = ut.chunkArray(self.urls, self.sitemapSize);
@@ -401,8 +413,9 @@ function SitemapIndex(urls, targetFolder, hostname, cacheTime, sitemapName, site
 
     var sitemap = createSitemap ({
       hostname: self.hostname,
-      cacheTime: self.cacheTime,        // 600 sec - cache purge period
-      urls: chunk
+      cacheTime: self.cacheTime, // 600 sec - cache purge period
+      urls: chunk,
+      xslUrl: self.xslUrl
     });
 
     var stream = self.fs.createWriteStream(targetFolder + '/' + filename);
@@ -420,6 +433,9 @@ function SitemapIndex(urls, targetFolder, hostname, cacheTime, sitemapName, site
   var xml = [];
 
   xml.push('<?xml version="1.0" encoding="UTF-8"?>');
+  if(self.xslUrl) {
+		xml.push('<?xml-stylesheet type="text/xsl" href="' + self.xslUrl + '"?>');
+	}
   xml.push('<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">');
 
   self.sitemaps.forEach( function (sitemap, index) {


### PR DESCRIPTION
It's now possible to add an xsl URL the sitemap.xml file via the parameter xslUrl. I edited the file rather quickly, because I needed it fast, but maybe I'm not the only one who likes to link to sitemaps in website footers and likes when even the sitemaps fit the general site design :)

I also weeded out some small typos, replaced this with the var it was already cached in and corrected some false references in method comments.