### PR TITLE
Added gzip functionality to index map

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Table of Contents
       * [Example of pre-generating sitemap based on existing static files:](#example-of-pre-generating-sitemap-based-on-existing-static-files)
       * [Example of indicating alternate language pages:](#example-of-indicating-alternate-language-pages)
       * [Example of Sitemap Styling](#example-of-sitemap-styling)
+      * [Example of mobile URL](#example-of-mobile-url)
     * [License](#license)
 
 TOC created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc)

--- a/lib/sitemap.js
+++ b/lib/sitemap.js
@@ -332,6 +332,16 @@ Sitemap.prototype.toString = function () {
   return self.setCache(xml.join('\n'));
 }
 
+Sitemap.prototype.toGzip = function(callback) {
+  var zlib = require('zlib');
+
+  if (typeof callback === 'function') {
+    zlib.gzip(this.toString(), callback);
+  } else {
+    return zlib.gzipSync(this.toString());
+  }
+}
+
 /**
  * Shortcut for `new SitemapIndex (...)`.
  *
@@ -353,6 +363,7 @@ function createSitemapIndex(conf) {
                             conf.sitemapName,
                             conf.sitemapSize,
                             conf.xslUrl,
+                            conf.gzip,
                             conf.callback);
 }
 
@@ -365,8 +376,10 @@ function createSitemapIndex(conf) {
  * @param {String}        sitemapName   optional
  * @param {Number}        sitemapSize   optional
  * @param {Number}        xslUrl				optional
+ * @param {Boolean}       gzip          optional
+ * @param {Function}      callback      optional
  */
-function SitemapIndex(urls, targetFolder, hostname, cacheTime, sitemapName, sitemapSize, xslUrl, callback) {
+function SitemapIndex(urls, targetFolder, hostname, cacheTime, sitemapName, sitemapSize, xslUrl, gzip, callback) {
 
   var self = this;
 
@@ -413,8 +426,9 @@ function SitemapIndex(urls, targetFolder, hostname, cacheTime, sitemapName, site
   var processesCount = self.chunks.length + 1;
 
   self.chunks.forEach( function (chunk, index) {
+    var extension = '.xml' + (gzip ? '.gz' : ''),
+        filename = self.sitemapName + '-' + self.sitemapId++ + extension;
 
-    var filename = self.sitemapName + '-' + self.sitemapId++ + '.xml';
     self.sitemaps.push(filename);
 
     var sitemap = createSitemap ({
@@ -426,7 +440,7 @@ function SitemapIndex(urls, targetFolder, hostname, cacheTime, sitemapName, site
 
     var stream = self.fs.createWriteStream(targetFolder + '/' + filename);
     stream.once('open', function(fd) {
-      stream.write(sitemap.toString());
+      stream.write(gzip ? sitemap.toGzip() : sitemap.toString());
       stream.end();
       processesCount--;
       if(processesCount === 0 && typeof self.callback === 'function') {


### PR DESCRIPTION
Hey, 

I added some functionality that I need to index maps. It is gzip compressing.
If provided "gzip" option to `createSitemapIndex` sitemap index will generate gzip compressed xml files.
Instead of "sitemap-0.xml" -> "sitemap-0.xml.gz".

I only wonder if we should generate also regular XML files in this case?