### PR TITLE
Adding support for Android app deep linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Table of Contents
       * [Example of dynamic page manipulations into sitemap:](#example-of-dynamic-page-manipulations-into-sitemap)
       * [Example of pre-generating sitemap based on existing static files:](#example-of-pre-generating-sitemap-based-on-existing-static-files)
       * [Example of indicating alternate language pages:](#example-of-indicating-alternate-language-pages)
+      * [Example of indicating Android app deep linking:](#example-of-indicating-android-app-deep-linking)
       * [Example of Sitemap Styling](#example-of-sitemap-styling)
       * [Example of mobile URL](#example-of-mobile-url)
       * [Example of using HH:MM:SS in lastmod](#example-of-using-hhmmss-in-lastmod)
@@ -156,6 +157,22 @@ var sm = sm.createSitemap({
 ```
 
 
+###Example of indicating Android app deep linking:
+
+[Description](https://developer.android.com/training/app-indexing/enabling-app-indexing.html#sitemap) in
+the google's Search Console Help.
+
+```javascript
+var sm = sm.createSitemap({
+      urls: [{
+        url: 'http://test.com/page-1/',
+        changefreq: 'weekly',
+        priority: 0.3,
+        androidLink: 'android-app://com.company.test/page-1/'
+      }]
+    });
+```
+
 ###Example of Sitemap Styling
 
 ```javascript
@@ -227,7 +244,7 @@ Testing
 ```bash
 ➥ git clone https://github.com/ekalinin/sitemap.js.git
 ➥ cd sitemap.js
-➥ make env 
+➥ make env
 ➥ . env/bin/activate
 (env) ➥ make test
 ./node_modules/expresso/bin/expresso ./tests/sitemap.test.js

--- a/lib/sitemap.js
+++ b/lib/sitemap.js
@@ -105,6 +105,7 @@ function SitemapItem(conf) {
   this.news = conf['news'] || null;
   this.img = conf['img'] || null;
   this.links = conf['links'] || null;
+  this.androidLink = conf['androidLink'] || null;
   this.mobile = conf['mobile'] || null;
 }
 
@@ -122,9 +123,9 @@ SitemapItem.prototype.toXML = function () {
  */
 SitemapItem.prototype.toString = function () {
   // result xml
-  var xml = '<url> {loc} {img} {lastmod} {changefreq} {priority} {links} {mobile} {news}</url>'
+  var xml = '<url> {loc} {img} {lastmod} {changefreq} {priority} {links} {androidLink} {mobile} {news}</url>'
   // xml property
-    , props = ['loc', 'img', 'lastmod', 'changefreq', 'priority', 'links', 'mobile', 'news']
+    , props = ['loc', 'img', 'lastmod', 'changefreq', 'priority', 'links', 'androidLink', 'mobile', 'news']
   // property array size (for loop)
     , ps = props.length
   // current property name (for loop)
@@ -152,6 +153,8 @@ SitemapItem.prototype.toString = function () {
         this[p].map(function (link) {
           return '<xhtml:link rel="alternate" hreflang="' + link.lang + '" href="' + safeUrl(link) + '" />';
         }).join(" "));
+    } else if (this[p] && p == 'androidLink') {
+      xml = xml.replace('{' + p + '}', '<xhtml:link rel="alternate" href="' + this[p] + '" />');
     } else if (this[p] && p == 'mobile') {
       xml = xml.replace('{' + p + '}', '<mobile:mobile/>');
     } else if (p == 'priority' && (this[p] >= 0.0 && this[p] <= 1.0)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starzplayarabia-sitemap",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Sitemap-generating framework based on Eugene Kalinin sitemap library",
   "keywords": [
     "sitemap",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "sitemap",
-  "version": "1.6.0",
-  "description": "Sitemap-generating framework",
+  "name": "starzplayarabia-sitemap",
+  "version": "1.6.1",
+  "description": "Sitemap-generating framework based on Eugene Kalinin sitemap library",
   "keywords": [
     "sitemap",
     "sitemap.xml"
   ],
-  "repository": "git://github.com/ekalinin/sitemap.js.git",
-  "author": "Eugene Kalinin <e.v.kalinin@gmail.com>",
+  "repository": "git://github.com/starzplayarabia/sitemap.js.git",
+  "author": "Starz Play Arabia <markel.arizaga@starzplayarabia.com> (http://www.arabia.starzplay.com)",
   "dependencies": {
     "underscore": "^1.7.0",
     "url-join": "^1.1.0"


### PR DESCRIPTION
A new property can be added to the URLs, called androidLink, where users can specify the deep linking for Android apps