### PR TITLE
Add support for image:caption

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - "5"
+  - "6"
+install:
+  - npm install
+script:
+  - npm test

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Table of Contents
       * [Example of synchronous sitemap.js usage:](#example-of-synchronous-sitemapjs-usage)
       * [Example of dynamic page manipulations into sitemap:](#example-of-dynamic-page-manipulations-into-sitemap)
       * [Example of pre-generating sitemap based on existing static files:](#example-of-pre-generating-sitemap-based-on-existing-static-files)
+      * [Example of images with captions:](#example-of-images-with-captions)
       * [Example of indicating alternate language pages:](#example-of-indicating-alternate-language-pages)
       * [Example of indicating Android app deep linking:](#example-of-indicating-android-app-deep-linking)
       * [Example of Sitemap Styling](#example-of-sitemap-styling)
@@ -136,6 +137,21 @@ var sitemap = sm.createSitemap({
 
 fs.writeFileSync("app/assets/sitemap.xml", sitemap.toString());
 ```
+
+###Example of images with captions:
+
+```javascript
+var sm = sm.createSitemap({
+      urls: [{
+        url: 'http://test.com/page-1/',
+        img: [
+          { url: 'http://test.com/img1.jpg', caption: 'An image'},
+          { url: 'http://test.com/img2.jpg', caption: 'Another image'}
+        ]
+      }]
+    });
+```
+
 
 ###Example of indicating alternate language pages:
 

--- a/lib/sitemap.js
+++ b/lib/sitemap.js
@@ -135,16 +135,21 @@ SitemapItem.prototype.toString = function () {
     p = props[ps];
 
     if (this[p] && p == 'img') {
+      imagexml = '';
       // Image handling
-      imagexml = '<image:image><image:loc>' + this[p] + '</image:loc></image:image>';
-      if (typeof(this[p]) == 'object') {
-        if (this[p] && this[p].length > 0) {
-          imagexml = '';
-          this[p].forEach(function (image) {
-            imagexml += '<image:image><image:loc>' + image + '</image:loc></image:image>';
-          });
-        }
+      if (typeof(this[p]) != 'object' || this[p].length == undefined) {
+        // make it an array
+        this[p] = [this[p]];
       }
+      this[p].forEach(function (image) {
+        if(typeof(image) != 'object') {
+          // it’s a string
+          // make it an object
+          image = {url: image};
+        }
+        caption = image.caption ? '<image:caption><![CDATA['+image.caption+']]></image:caption>' : '';
+        imagexml += '<image:image><image:loc>' + image.url + '</image:loc>' + caption + '</image:image>';
+      });
 
       xml = xml.replace('{' + p + '}', imagexml);
 

--- a/tests/sitemap.test.js
+++ b/tests/sitemap.test.js
@@ -658,8 +658,8 @@ module.exports = {
     smap.toXML(function (err, xml) {
       assert.eql(err, error);
     });
-},
-  'sitemap: android app linking': function(){
+  },
+  'sitemap: android app linking': function() {
     var smap = sm.createSitemap({
           urls: [
             { url: 'http://test.com/page-1/',  changefreq: 'weekly', priority: 0.3,
@@ -676,5 +676,51 @@ module.exports = {
                   '<xhtml:link rel="alternate" href="android-app://com.company.test/page-1/" /> '+
                 '</url>\n'+
               '</urlset>');
+  },
+  'sitemap: image with caption': function() {
+    var smap = sm.createSitemap({
+      urls: [
+        { url: 'http://test.com', img: {url: 'http://test.com/image.jpg', caption: 'Test Caption'}}
+      ]
+    });
+
+    assert.eql(smap.toString(),
+      '<?xml version="1.0" encoding="UTF-8"?>\n'+
+      urlset + '\n'+
+        '<url> '+
+            '<loc>http://test.com</loc> '+
+            '<image:image>'+
+                '<image:loc>http://test.com/image.jpg</image:loc>'+
+                '<image:caption><![CDATA[Test Caption]]></image:caption>'+
+            '</image:image> '+
+        '</url>\n'+
+      '</urlset>')
+  },
+  'sitemap: images with captions': function() {
+    var smap = sm.createSitemap({
+      urls: [
+        { url: 'http://test.com', img: {url: 'http://test.com/image.jpg', caption: 'Test Caption'}},
+        { url: 'http://test.com/page2/', img: {url: 'http://test.com/image2.jpg', caption: 'Test Caption 2'}}
+      ]
+    });
+
+    assert.eql(smap.toString(),
+      '<?xml version="1.0" encoding="UTF-8"?>\n'+
+      urlset + '\n'+
+        '<url> '+
+            '<loc>http://test.com</loc> '+
+            '<image:image>'+
+                '<image:loc>http://test.com/image.jpg</image:loc>'+
+                '<image:caption><![CDATA[Test Caption]]></image:caption>'+
+            '</image:image> '+
+        '</url>\n'+
+        '<url> '+
+            '<loc>http://test.com/page2/</loc> '+
+            '<image:image>'+
+                '<image:loc>http://test.com/image2.jpg</image:loc>'+
+                '<image:caption><![CDATA[Test Caption 2]]></image:caption>'+
+            '</image:image> '+
+        '</url>\n'+
+      '</urlset>')
   }
 }


### PR DESCRIPTION
This pull request replaces #63. It adds support for `image:caption` by allowing the `img` property value not only being a string but also an object, as shown in the example in the README.md

```js
var sm = sm.createSitemap({
      urls: [{
        url: 'http://test.com/page-1/',
        img: [
          { url: 'http://test.com/img1.jpg', caption: 'An image'},
          { url: 'http://test.com/img2.jpg', caption: 'Another image'}
        ]
      }]
    });
```

Tests are included and succeed.
I also added a travis configuration file. It might make sense to setup a free [travis integration](https://travis-ci.org) to watch this repo and run the tests as I did in my fork.