### PR TITLE
Minor fix + updated readme to include video sitemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,22 @@ var sm = sm.createSitemap({
     });
 ```
 
+###Example of videos:
+
+[Description](https://developers.google.com/webmasters/videosearch/sitemaps) specifications. Required fields are thumbnail_loc, title, and description.
+
+```javascript
+var sm = sm.createSitemap({
+      urls: [{
+        url: 'http://test.com/page-1/',
+        video: [
+          { thumbnail_loc: 'http://test.com/tmbn1.jpg', title: 'A video title', description: 'This is a video' },
+          { thumbnail_loc: 'http://test.com/tmbn2.jpg', title: 'Another video title', description: 'This is another video' },
+        ]
+      }]
+    });
+```
+
 
 ###Example of indicating alternate language pages:
 

--- a/lib/sitemap.js
+++ b/lib/sitemap.js
@@ -169,7 +169,7 @@ SitemapItem.prototype.toString = function () {
           // has to be an object and include required categories https://developers.google.com/webmasters/videosearch/sitemaps
           throw new err.InvalidVideoFormat();
         }
-        videoxml += '<video:video><video:loc>' + video.url + '</video:loc>' +
+        videoxml += '<video:video>' +
           '<video:thumbnail_loc>' + video.thumbnail_loc + '</video:thumbnail_loc>' +
           '<video:title>' + video.title + '</video:title>' +
           '<video:description>' + video.description + '</video:description>';


### PR DESCRIPTION
Accidentally included <video:loc> tag, which doesn't exist. The video location is covered by <video:content_loc>tag. 
Updated README.