### PR TITLE
Mirror sitemap schema order of <url> children

### DIFF
--- a/lib/sitemap.js
+++ b/lib/sitemap.js
@@ -133,7 +133,7 @@ SitemapItem.prototype.toXML = function () {
  */
 SitemapItem.prototype.toString = function () {
   // result xml
-  var xml = '<url> {loc} {img} {video} {lastmod} {changefreq} {priority} {links} {expires} {androidLink} {mobile} {news} {ampLink}</url>'
+  var xml = '<url> {loc} {lastmod} {changefreq} {priority} {img} {video} {links} {expires} {androidLink} {mobile} {news} {ampLink}</url>'
   // xml property
     , props = ['loc', 'img', 'video', 'lastmod', 'changefreq', 'priority', 'links', 'expires', 'androidLink', 'mobile', 'news', 'ampLink']
   // property array size (for loop)

--- a/tests/sitemap.test.js
+++ b/tests/sitemap.test.js
@@ -59,14 +59,14 @@ module.exports = {
     assert.eql(smi.toString(),
               '<url> '+
                   '<loc>http://ya.ru</loc> '+
-                  '<image:image>'+
-                    '<image:loc>'+
-                      'http://urlTest.com'+
-                    '</image:loc>'+
-                  '</image:image> '+
                   '<lastmod>2011-06-27</lastmod> '+
                   '<changefreq>always</changefreq> '+
                   '<priority>0.9</priority> '+
+                  '<image:image>'+
+                  '<image:loc>'+
+                  'http://urlTest.com'+
+                  '</image:loc>'+
+                  '</image:image> '+
                   '<mobile:mobile/> '+
               '</url>');
   },
@@ -111,14 +111,14 @@ module.exports = {
     assert.eql(smi.toString(),
               '<url> '+
                   '<loc>http://ya.ru</loc> '+
-                  '<image:image>'+
-                    '<image:loc>'+
-                      'http://urlTest.com'+
-                    '</image:loc>'+
-                  '</image:image> '+
                   '<lastmod>'+ lastmod +'</lastmod> '+
                   '<changefreq>always</changefreq> '+
                   '<priority>0.9</priority> '+
+                  '<image:image>'+
+                  '<image:loc>'+
+                  'http://urlTest.com'+
+                  '</image:loc>'+
+                  '</image:image> '+
               '</url>');
   },
   'sitemap item: lastmod from file with lastmodrealtime': function () {
@@ -145,14 +145,14 @@ module.exports = {
     assert.eql(smi.toString(),
               '<url> '+
                   '<loc>http://ya.ru</loc> '+
-                  '<image:image>'+
-                    '<image:loc>'+
-                      'http://urlTest.com'+
-                    '</image:loc>'+
-                  '</image:image> '+
                   '<lastmod>'+ lastmod +'</lastmod> '+
                   '<changefreq>always</changefreq> '+
                   '<priority>0.9</priority> '+
+                  '<image:image>'+
+                  '<image:loc>'+
+                  'http://urlTest.com'+
+                  '</image:loc>'+
+                  '</image:image> '+
               '</url>');
   },
   'sitemap item: toXML': function () {
@@ -168,14 +168,14 @@ module.exports = {
     assert.eql(smi.toString(),
               '<url> '+
                   '<loc>http://ya.ru</loc> '+
+                  '<lastmod>2011-06-27</lastmod> '+
+                  '<changefreq>always</changefreq> '+
+                  '<priority>0.9</priority> '+
                   '<image:image>'+
                       '<image:loc>'+
                         'http://urlTest.com'+
                       '</image:loc>'+
                   '</image:image> '+
-                  '<lastmod>2011-06-27</lastmod> '+
-                  '<changefreq>always</changefreq> '+
-                  '<priority>0.9</priority> '+
               '</url>');
   },
   'sitemap empty urls': function () {
@@ -434,11 +434,11 @@ module.exports = {
                 '</url>\n'+
                 '<url> '+
                     '<loc>http://test.com/page-3/</loc> '+
+                    '<changefreq>monthly</changefreq> '+
+                    '<priority>0.2</priority> '+
                     '<image:image>'+
                         '<image:loc>http://test.com/image.jpg</image:loc>'+
                     '</image:image> '+
-                    '<changefreq>monthly</changefreq> '+
-                    '<priority>0.2</priority> '+
                 '</url>\n'+
                 '<url> '+
                     '<loc>http://www.test.com/page-4/</loc> '+


### PR DESCRIPTION
**This PR alters element order to adhere to the sitemap schema**

I was validating my output (URLs and Images) with xmllint and encountered an error that `lastmod` wasn't expected.

I believe this is because the sitemap schema description: https://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd has this XSD sequence:
```xml
<xsd:sequence>
  <xsd:element name="loc" type="tLoc"/>
  <xsd:element name="lastmod" type="tLastmod" minOccurs="0"/>
  <xsd:element name="changefreq" type="tChangeFreq" minOccurs="0"/>
  <xsd:element name="priority" type="tPriority" minOccurs="0"/>
  <xsd:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="strict"/>
</xsd:sequence>
```
...and in the current `sitemap.js` the string replacement puts image between loc and lastmod.

In the diff, I've changed the order of the string substitution to mirror the order above.

The result is my new output validates.