### PR TITLE
Perf baseline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ test:
 	./node_modules/expresso/bin/expresso ./tests/sitemap.test.js
 
 test-perf:
-	node tests/perf.js
+	node tests/perf.js $(runs)
 
 deploy-github:
 	@git tag `grep "version" package.json | grep -o -E '[0-9]\.[0-9]{1,2}\.[0-9]{1,2}'`

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,13 +16,19 @@
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
       "dev": true,
       "requires": {
-        "samsam": "1.1.2"
+        "samsam": "~1.1"
       }
     },
     "inherits": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
       "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+      "dev": true
+    },
+    "isnumber": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isnumber/-/isnumber-1.0.0.tgz",
+      "integrity": "sha1-Dj+XWbWB2Z3YUIbw7Cp0kJz63QE=",
       "dev": true
     },
     "lolex": {
@@ -46,7 +52,16 @@
         "formatio": "1.1.1",
         "lolex": "1.3.2",
         "samsam": "1.1.2",
-        "util": "0.10.3"
+        "util": ">=0.10.3 <1"
+      }
+    },
+    "stats-lite": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/stats-lite/-/stats-lite-2.1.1.tgz",
+      "integrity": "sha512-5QkxGCWGMbeQ+PXqI2N7ES6kW4IimvbMQBCKvZbekaEpf3InckVHiIXdCJbZsKUjLE7a3jha2cTEJqtOGGcVMw==",
+      "dev": true,
+      "requires": {
+        "isnumber": "~1.0.0"
       }
     },
     "underscore": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "devDependencies": {
     "expresso": "^0.9.2",
-    "sinon": "^1.16.1"
+    "sinon": "^1.16.1",
+    "stats-lite": "^2.1.1"
   },
   "main": "index",
   "scripts": {

--- a/tests/perf.js
+++ b/tests/perf.js
@@ -74,4 +74,3 @@ function toXMLCB (xml) {
 }
 start = performance.now()
 sitemap.toXML(toXMLCB)
-console.log(runs)


### PR DESCRIPTION
Added real 16mb of 21 thousand entries courtesy of roosterteeth.com

This is a change in advance of a re-write of the library to ensure future changes do not severely degrade performance.

```
# Test results from 2016 MBP
$ make test-perf runs=100
node tests/perf.js 100
=========  sitemap creation  =============
mean: 2.37
median: 2.11
variance: 0.64
standard deviation: 0.80
90th percentile: 3.24
99th percentile: 5.98
=========  sync  =============
mean: 762.26
median: 759.54
variance: 362.99
standard deviation: 19.05
90th percentile: 780.80
99th percentile: 852.34
=========  async  =============
mean: 765.70
median: 759.55
variance: 738.42
standard deviation: 27.17
90th percentile: 779.57
99th percentile: 911.93
```