### PR TITLE
Swap test framework, add coverage report

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ node_modules/
 
 # Emacs
 *~
+
+# code coverage
+coverage/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-  - "5"
   - "6"
+  - "8"
+  - "10"
 install:
   - npm install
 script:

--- a/lib/sitemap.js
+++ b/lib/sitemap.js
@@ -8,8 +8,7 @@ var ut = require('./utils')
   , err = require('./errors')
   , urlparser = require('url')
   , fs = require('fs')
-  , urljoin = require('url-join')
-  , _ = require('underscore');
+  , urljoin = require('url-join');
 
 exports.Sitemap = Sitemap;
 exports.SitemapItem = SitemapItem;
@@ -373,7 +372,7 @@ function Sitemap(urls, hostname, cacheTime, xslUrl, xmlNs) {
   this.urls = [];
 
   // Make copy of object
-  if (urls) _.extend(this.urls, (urls instanceof Array) ? urls : [urls]);
+  if (urls) Object.assign(this.urls, (urls instanceof Array) ? urls : [urls]);
 
   // sitemap cache
   this.cacheResetPeriod = cacheTime || 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,19 +4,212 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "expresso": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/expresso/-/expresso-0.9.2.tgz",
-      "integrity": "sha1-F3smCQisrr5F7hbd90SVo/VYYug=",
+    "abbrev": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
       "dev": true
     },
-    "formatio": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
-      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "samsam": "1.1.2"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
+      }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+      "dev": true,
+      "optional": true
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
+      }
+    },
+    "cliui": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
+        "wordwrap": "0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
+      "optional": true
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "escodegen": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+      "dev": true,
+      "requires": {
+        "esprima": "^2.7.1",
+        "estraverse": "^1.9.1",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.2.0"
+      }
+    },
+    "esprima": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "dev": true
+    },
+    "estraverse": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "handlebars": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+      "dev": true,
+      "requires": {
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
+      }
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -25,29 +218,298 @@
       "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
       "dev": true
     },
-    "lolex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
-      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
-    "samsam": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
-      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "sinon": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
-      "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+    "istanbul": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
+      "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
       "requires": {
-        "formatio": "1.1.1",
-        "lolex": "1.3.2",
-        "samsam": "1.1.2",
-        "util": "0.10.3"
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.8.x",
+        "esprima": "2.7.x",
+        "glob": "^5.0.15",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "once": "1.x",
+        "resolve": "1.1.x",
+        "supports-color": "^3.1.0",
+        "which": "^1.1.1",
+        "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
+    },
+    "jasmine": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.1.0.tgz",
+      "integrity": "sha1-K9Wf1+xuwOistk4J9Fpo7SrRlSo=",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.6",
+        "jasmine-core": "~3.1.0"
+      }
+    },
+    "jasmine-core": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.1.0.tgz",
+      "integrity": "sha1-pHheE11d9lAk38kiSVPfWFvSdmw=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+          "dev": true
+        }
+      }
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "requires": {
+        "is-buffer": "^1.1.5"
+      }
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true,
+      "optional": true
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+      "dev": true
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "^0.1.1"
+      }
+    },
+    "source-map": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+      "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "amdefine": ">=0.0.4"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+      "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+      "dev": true,
+      "requires": {
+        "has-flag": "^1.0.0"
+      }
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "uglify-js": {
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true,
+      "optional": true
     },
     "underscore": {
       "version": "1.9.0",
@@ -59,13 +521,45 @@
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.0.tgz",
       "integrity": "sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo="
     },
-    "util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.1"
+        "isexe": "^2.0.0"
+      }
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "dev": true,
+      "optional": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
+        "window-size": "0.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,11 +14,19 @@
     "url-join": "^4.0.0"
   },
   "devDependencies": {
-    "expresso": "^0.9.2",
-    "sinon": "^1.16.1"
+    "istanbul": "^0.4.5",
+    "jasmine": "^3.1.0"
   },
+  "standard": {
+    "env": {
+      "jasmine": true,
+      "node": true
+    }
+  },
+  "license": "MIT",
   "main": "index",
   "scripts": {
-    "test": "./node_modules/expresso/bin/expresso tests/sitemap.test.js"
+    "test": "istanbul cover --include-all-sources jasmine tests/sitemap.test.js",
+    "coverage": "open ./coverage/lcov-report/index.html"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "istanbul": "^0.4.5",
     "jasmine": "^3.1.0"
   },
+  "engines": {
+    "npm": "^4.0.0",
+    "node": ">=6.0.0"
+  },
   "standard": {
     "env": {
       "jasmine": true,

--- a/tests/jasmine.json
+++ b/tests/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": true
+}

--- a/tests/sitemap.test.js
+++ b/tests/sitemap.test.js
@@ -4,1010 +4,429 @@
  * MIT Licensed
  */
 
-var sm = require('../index'),
-    fs = require('fs'),
-    zlib = require('zlib'),
-    assert = require('assert'),
-    sinon = require('sinon');
+const sm = require('../index')
+const fs = require('fs')
+const zlib = require('zlib')
 
-var urlset = '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" ' +
+const urlset = '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" ' +
              'xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" ' +
              'xmlns:xhtml="http://www.w3.org/1999/xhtml" ' +
              'xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" ' +
              'xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" ' +
-             'xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">';
+             'xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">'
 
-var dynamicUrlSet = '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
+const dynamicUrlSet = '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+const xmlDef = '<?xml version="1.0" encoding="UTF-8"?>\n'
+const xmlPriority = '<priority>0.9</priority> '
+const xmlLoc = '<loc>http://ya.ru</loc> '
 
-var removeFilesArray = function(files) {
+var removeFilesArray = function (files) {
   if (files && files.length) {
-    files.forEach(function(file) {
+    files.forEach(function (file) {
       if (fs.existsSync(file)) {
-        fs.unlinkSync(file);
+        fs.unlinkSync(file)
       }
-    });
+    })
   }
-};
+}
 
-module.exports = {
-  'sitemap item: default values && escape': function () {
-    var url = 'http://ya.ru/view?widget=3&count>2'
-      , smi = new sm.SitemapItem({'url': url});
+describe('sitemapItem', () => {
+  it('sitemap item: default values && escape', () => {
+    const url = 'http://ya.ru/view?widget=3&count>2'
+    const smi = new sm.SitemapItem({'url': url})
 
-    assert.eql(smi.toString(),
-              '<url> '+
-                  '<loc>http://ya.ru/view?widget=3&amp;count&gt;2</loc> '+
-              '</url>');
-  },
-  'sitemap item: error for url absence': function () {
-    assert.throws(
-      function() { new sm.SitemapItem(); },
-      /URL is required/
-    );
-  },
-  'sitemap item: full options': function () {
+    expect(smi.toString()).toBe(
+      '<url> ' +
+                  '<loc>http://ya.ru/view?widget=3&amp;count&gt;2</loc> ' +
+              '</url>')
+  })
+  it('sitemap item: error for url absence', () => {
+    /* eslint-disable no-new */
+    expect(
+      function () { new sm.SitemapItem() }
+    ).toThrowError(/URL is required/)
+  })
+  it('sitemap item: full options', () => {
+    const url = 'http://ya.ru'
+    const smi = new sm.SitemapItem({
+      'url': url,
+      'img': 'http://urlTest.com',
+      'lastmod': '2011-06-27',
+      'changefreq': 'always',
+      'priority': 0.9,
+      'mobile': true
+    })
+
+    expect(smi.toString()).toBe(
+      '<url> ' +
+                  xmlLoc +
+                  '<lastmod>2011-06-27</lastmod> ' +
+                  '<changefreq>always</changefreq> ' +
+                  xmlPriority +
+                  '<image:image>' +
+                  '<image:loc>' +
+                  'http://urlTest.com' +
+                  '</image:loc>' +
+                  '</image:image> ' +
+                  '<mobile:mobile/> ' +
+              '</url>')
+  })
+  it('sitemap item: lastmodISO', () => {
+    const url = 'http://ya.ru'
+    const smi = new sm.SitemapItem({
+      'url': url,
+      'lastmodISO': '2011-06-27T00:00:00.000Z',
+      'changefreq': 'always',
+      'priority': 0.9
+    })
+
+    expect(smi.toString()).toBe(
+      '<url> ' +
+                  xmlLoc +
+                  '<lastmod>2011-06-27T00:00:00.000Z</lastmod> ' +
+                  '<changefreq>always</changefreq> ' +
+                  xmlPriority +
+              '</url>')
+  })
+  it('sitemap item: lastmod from file', () => {
+    var tempFile = require('fs').openSync('/tmp/tempFile.tmp', 'w')
+    require('fs').closeSync(tempFile)
+
+    var stat = require('fs').statSync('/tmp/tempFile.tmp')
+
+    var dt = new Date(stat.mtime)
+    var lastmod = sm.utils.getTimestampFromDate(dt)
+
+    const url = 'http://ya.ru'
+    const smi = new sm.SitemapItem({
+      'url': url,
+      'img': 'http://urlTest.com',
+      'lastmodfile': '/tmp/tempFile.tmp',
+      'changefreq': 'always',
+      'priority': 0.9
+    })
+
+    require('fs').unlinkSync('/tmp/tempFile.tmp')
+
+    expect(smi.toString()).toBe(
+      '<url> ' +
+                  xmlLoc +
+                  '<lastmod>' + lastmod + '</lastmod> ' +
+                  '<changefreq>always</changefreq> ' +
+                  xmlPriority +
+                  '<image:image>' +
+                  '<image:loc>' +
+                  'http://urlTest.com' +
+                  '</image:loc>' +
+                  '</image:image> ' +
+              '</url>')
+  })
+  it('sitemap item: lastmod from file with lastmodrealtime', () => {
+    var tempFile = require('fs').openSync('/tmp/tempFile.tmp', 'w')
+    require('fs').closeSync(tempFile)
+
+    var stat = require('fs').statSync('/tmp/tempFile.tmp')
+
+    var dt = new Date(stat.mtime)
+    var lastmod = sm.utils.getTimestampFromDate(dt, true)
+
+    const url = 'http://ya.ru'
+    const smi = new sm.SitemapItem({
+      'url': url,
+      'img': 'http://urlTest.com',
+      'lastmodfile': '/tmp/tempFile.tmp',
+      'lastmodrealtime': true,
+      'changefreq': 'always',
+      'priority': 0.9
+    })
+
+    require('fs').unlinkSync('/tmp/tempFile.tmp')
+
+    expect(smi.toString()).toBe(
+      '<url> ' +
+                  xmlLoc +
+                  '<lastmod>' + lastmod + '</lastmod> ' +
+                  '<changefreq>always</changefreq> ' +
+                  xmlPriority +
+                  '<image:image>' +
+                  '<image:loc>' +
+                  'http://urlTest.com' +
+                  '</image:loc>' +
+                  '</image:image> ' +
+              '</url>')
+  })
+  it('sitemap item: toXML', () => {
+    const url = 'http://ya.ru'
+    const smi = new sm.SitemapItem({
+      'url': url,
+      'img': 'http://urlTest.com',
+      'lastmod': '2011-06-27',
+      'changefreq': 'always',
+      'priority': 0.9
+    })
+
+    expect(smi.toString()).toBe(
+      '<url> ' +
+                  xmlLoc +
+                  '<lastmod>2011-06-27</lastmod> ' +
+                  '<changefreq>always</changefreq> ' +
+                  xmlPriority +
+                  '<image:image>' +
+                      '<image:loc>' +
+                        'http://urlTest.com' +
+                      '</image:loc>' +
+                  '</image:image> ' +
+              '</url>')
+  })
+  it('sitemap: video price type', () => {
+    expect(function () {
+      var smap = new sm.SitemapItem({
+        'url': 'https://roosterteeth.com/episode/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club',
+        'video': [{
+          'title': "2008:E2 - Burnout Paradise: Millionaire's Club",
+          'description': 'Lorem ipsum',
+          'player_loc': 'https://roosterteeth.com/embed/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club',
+          'thumbnail_loc': 'https://rtv3-img-roosterteeth.akamaized.net/uploads/images/e82e1925-89dd-4493-9bcf-cdef9665d726/sm/ep298.jpg',
+          'price': '1.99',
+          'price:type': 'subscription'
+        }]
+      })
+      smap.toString()
+    }).toThrowError(/is not a valid value for attr: "price:type"/)
+  })
+  it('sitemap: video price currency', () => {
+    expect(function () {
+      var smap = new sm.SitemapItem({
+        'url': 'https://roosterteeth.com/episode/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club',
+        'video': [{
+          'title': "2008:E2 - Burnout Paradise: Millionaire's Club",
+          'description': 'Lorem ipsum',
+          'player_loc': 'https://roosterteeth.com/embed/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club',
+          'thumbnail_loc': 'https://rtv3-img-roosterteeth.akamaized.net/uploads/images/e82e1925-89dd-4493-9bcf-cdef9665d726/sm/ep298.jpg',
+          'price': '1.99',
+          'price:currency': 'dollar'
+        }]
+      })
+      smap.toString()
+    }).toThrowError(/is not a valid value for attr: "price:currency"/)
+  })
+  it('sitemap: video price resolution', () => {
+    expect(function () {
+      var smap = new sm.SitemapItem({
+        'url': 'https://roosterteeth.com/episode/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club',
+        'video': [{
+          'title': "2008:E2 - Burnout Paradise: Millionaire's Club",
+          'description': 'Lorem ipsum',
+          'player_loc': 'https://roosterteeth.com/embed/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club',
+          'thumbnail_loc': 'https://rtv3-img-roosterteeth.akamaized.net/uploads/images/e82e1925-89dd-4493-9bcf-cdef9665d726/sm/ep298.jpg',
+          'price': '1.99',
+          'price:resolution': '1920x1080'
+        }]
+      })
+      smap.toString()
+    }).toThrowError(/is not a valid value for attr: "price:resolution"/)
+  })
+  it('sitemap: video platform relationship', () => {
+    expect(function () {
+      var smap = new sm.SitemapItem({
+        'url': 'https://roosterteeth.com/episode/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club',
+        'video': [{
+          'title': "2008:E2 - Burnout Paradise: Millionaire's Club",
+          'description': 'Lorem ipsum',
+          'player_loc': 'https://roosterteeth.com/embed/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club',
+          'thumbnail_loc': 'https://rtv3-img-roosterteeth.akamaized.net/uploads/images/e82e1925-89dd-4493-9bcf-cdef9665d726/sm/ep298.jpg',
+          'platform': 'tv',
+          'platform:relationship': 'mother'
+        }]
+      })
+      smap.toString()
+    }).toThrowError(/is not a valid value for attr: "platform:relationship"/)
+  })
+  it('sitemap: video restriction', () => {
+    expect(function () {
+      var smap = new sm.SitemapItem({
+        'url': 'https://roosterteeth.com/episode/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club',
+        'video': [{
+          'title': "2008:E2 - Burnout Paradise: Millionaire's Club",
+          'description': 'Lorem ipsum',
+          'player_loc': 'https://roosterteeth.com/embed/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club',
+          'thumbnail_loc': 'https://rtv3-img-roosterteeth.akamaized.net/uploads/images/e82e1925-89dd-4493-9bcf-cdef9665d726/sm/ep298.jpg',
+          'restriction': 'IE GB US CA',
+          'restriction:relationship': 'father'
+        }]
+      })
+      smap.toString()
+    }).toThrowError(/is not a valid value for attr: "restriction:relationship"/)
+  })
+  it('sitemap: video duration', () => {
+    expect(function () {
+      var smap = new sm.SitemapItem({
+        'url': 'https://roosterteeth.com/episode/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club',
+        'video': [{
+          'title': "2008:E2 - Burnout Paradise: Millionaire's Club",
+          'description': "Jack gives us a walkthrough on getting the Millionaire's Club Achievement in Burnout Paradise.",
+          'player_loc': 'https://roosterteeth.com/embed/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club',
+          'thumbnail_loc': 'https://rtv3-img-roosterteeth.akamaized.net/uploads/images/e82e1925-89dd-4493-9bcf-cdef9665d726/sm/ep298.jpg',
+          'duration': -1,
+          'publication_date': '2008-07-29T14:58:04.000Z',
+          'requires_subscription': false
+        }]
+      })
+      smap.toString()
+    }).toThrowError(/duration must be an integer/)
+  })
+  it('sitemap: video description limit', () => {
+    expect(function () {
+      var smap = new sm.SitemapItem({
+        'url': 'https://roosterteeth.com/episode/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club',
+        'video': [{
+          'title': "2008:E2 - Burnout Paradise: Millionaire's Club",
+          'description': 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue velit cursus nunc, quis gravida magna mi a libero. Fusce vulputate eleifend sapien. Vestibulum purus quam, scelerisque ut, mollis sed, nonummy id, metus. Nullam accumsan lorem in dui. Cras ultricies mi eu turpis hendrerit fringilla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; In ac dui quis mi consectetuer lacinia. Nam pretium turpis et arcu. Duis arcu tortor, suscipit eget, imperdiet nec, imperdiet iaculis, ipsum. Sed aliquam ultrices mauris. Integer ante arcu, accumsan a, consectetuer eget, posuere ut, mauris. Praesent adipiscing. Phasellus ullamcorper ipsum rutrum nunc. Nunc nonummy metus. Vestibulum volutpat pretium libero. Cras id dui. Aenean ut eros et nisl sagittis vestibulum. Nullam nulla.',
+          'player_loc': 'https://roosterteeth.com/embed/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club',
+          'thumbnail_loc': 'https://rtv3-img-roosterteeth.akamaized.net/uploads/images/e82e1925-89dd-4493-9bcf-cdef9665d726/sm/ep298.jpg',
+          'duration': -1,
+          'publication_date': '2008-07-29T14:58:04.000Z',
+          'requires_subscription': false
+        }]
+      })
+      smap.toString()
+    }).toThrowError(/2048 characters/)
+  })
+})
+describe('sitemap', () => {
+  it('sitemap empty urls', () => {
+    const smEmpty = new sm.Sitemap()
+
+    expect(smEmpty.urls).toEqual([])
+  })
+  it('sitemap.urls is an array', () => {
+    const url = 'ya.ru'
+    const smOne = new sm.Sitemap(url)
+
+    expect(smOne.urls).toEqual([url])
+  })
+  it('simple sitemap', () => {
     var url = 'http://ya.ru'
-      , smi = new sm.SitemapItem({
-          'url': url,
-          'img': "http://urlTest.com",
-          'lastmod': '2011-06-27',
-          'changefreq': 'always',
-          'priority': 0.9,
-          'mobile' : true
-        });
+    var ssp = new sm.Sitemap()
+    ssp.add(url)
 
-    assert.eql(smi.toString(),
-              '<url> '+
-                  '<loc>http://ya.ru</loc> '+
-                  '<lastmod>2011-06-27</lastmod> '+
-                  '<changefreq>always</changefreq> '+
-                  '<priority>0.9</priority> '+
-                  '<image:image>'+
-                  '<image:loc>'+
-                  'http://urlTest.com'+
-                  '</image:loc>'+
-                  '</image:image> '+
-                  '<mobile:mobile/> '+
-              '</url>');
-  },
-  'sitemap item: lastmodISO': function () {
+    expect(ssp.toString()).toBe(
+      xmlDef +
+                urlset + '\n' +
+                '<url> ' +
+                    xmlLoc +
+                '</url>\n' +
+              '</urlset>')
+  })
+  it('simple sitemap with dynamic xmlNs', () => {
     var url = 'http://ya.ru'
-      , smi = new sm.SitemapItem({
-          'url': url,
-          'lastmodISO': '2011-06-27T00:00:00.000Z',
-          'changefreq': 'always',
-          'priority': 0.9
-        });
-
-    assert.eql(smi.toString(),
-              '<url> '+
-                  '<loc>http://ya.ru</loc> '+
-                  '<lastmod>2011-06-27T00:00:00.000Z</lastmod> '+
-                  '<changefreq>always</changefreq> '+
-                  '<priority>0.9</priority> '+
-              '</url>');
-  },
-  'sitemap item: lastmod from file': function () {
-    var tempFile = require('fs').openSync('/tmp/tempFile.tmp', 'w');
-    require('fs').closeSync(tempFile);
-
-    var stat = require('fs').statSync('/tmp/tempFile.tmp');
-
-
-    var dt = new Date( stat.mtime );
-    var lastmod = sm.utils.getTimestampFromDate(dt);
-
-    var url = 'http://ya.ru'
-      , smi = new sm.SitemapItem({
-          'url': url,
-          'img': "http://urlTest.com",
-          'lastmodfile': '/tmp/tempFile.tmp',
-          'changefreq': 'always',
-          'priority': 0.9
-        });
-
-    require('fs').unlinkSync('/tmp/tempFile.tmp');
-
-    assert.eql(smi.toString(),
-              '<url> '+
-                  '<loc>http://ya.ru</loc> '+
-                  '<lastmod>'+ lastmod +'</lastmod> '+
-                  '<changefreq>always</changefreq> '+
-                  '<priority>0.9</priority> '+
-                  '<image:image>'+
-                  '<image:loc>'+
-                  'http://urlTest.com'+
-                  '</image:loc>'+
-                  '</image:image> '+
-              '</url>');
-  },
-  'sitemap item: lastmod from file with lastmodrealtime': function () {
-    var tempFile = require('fs').openSync('/tmp/tempFile.tmp', 'w');
-    require('fs').closeSync(tempFile);
-
-    var stat = require('fs').statSync('/tmp/tempFile.tmp');
-
-    var dt = new Date( stat.mtime );
-    var lastmod = sm.utils.getTimestampFromDate(dt, true);
-
-    var url = 'http://ya.ru'
-      , smi = new sm.SitemapItem({
-          'url': url,
-          'img': "http://urlTest.com",
-          'lastmodfile': '/tmp/tempFile.tmp',
-          'lastmodrealtime': true,
-          'changefreq': 'always',
-          'priority': 0.9
-        });
-
-    require('fs').unlinkSync('/tmp/tempFile.tmp');
-
-    assert.eql(smi.toString(),
-              '<url> '+
-                  '<loc>http://ya.ru</loc> '+
-                  '<lastmod>'+ lastmod +'</lastmod> '+
-                  '<changefreq>always</changefreq> '+
-                  '<priority>0.9</priority> '+
-                  '<image:image>'+
-                  '<image:loc>'+
-                  'http://urlTest.com'+
-                  '</image:loc>'+
-                  '</image:image> '+
-              '</url>');
-  },
-  'sitemap item: toXML': function () {
-    var url = 'http://ya.ru'
-      , smi = new sm.SitemapItem({
-          'url': url,
-          'img': "http://urlTest.com",
-          'lastmod': '2011-06-27',
-          'changefreq': 'always',
-          'priority': 0.9
-        });
-
-    assert.eql(smi.toString(),
-              '<url> '+
-                  '<loc>http://ya.ru</loc> '+
-                  '<lastmod>2011-06-27</lastmod> '+
-                  '<changefreq>always</changefreq> '+
-                  '<priority>0.9</priority> '+
-                  '<image:image>'+
-                      '<image:loc>'+
-                        'http://urlTest.com'+
-                      '</image:loc>'+
-                  '</image:image> '+
-              '</url>');
-  },
-  'sitemap empty urls': function () {
-    var sm_empty = new sm.Sitemap();
-
-    assert.eql(sm_empty.urls, [])
-  },
-  'sitemap.urls is an array': function () {
-    var url = 'ya.ru';
-    var sm_one = new sm.Sitemap(url);
-
-    assert.eql(sm_one.urls, [url]);
-  },
-  'simple sitemap': function() {
-    var url = 'http://ya.ru';
-    var ssp = new sm.Sitemap();
-    ssp.add(url);
-
-    assert.eql(ssp.toString(),
-              '<?xml version="1.0" encoding="UTF-8"?>\n'+
-                urlset + '\n'+
-                '<url> '+
-                    '<loc>http://ya.ru</loc> '+
-                '</url>\n'+
-              '</urlset>');
-  },
-  'simple sitemap with dynamic xmlNs': function() {
-    var url = 'http://ya.ru';
     var ssp = sm.createSitemap({
-      xmlNs: 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"',
-    });
-    ssp.add(url);
+      xmlNs: 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"'
+    })
+    ssp.add(url)
 
-    assert.eql(ssp.toString(),
-              '<?xml version="1.0" encoding="UTF-8"?>\n'+
-                dynamicUrlSet + '\n'+
-                '<url> '+
-                    '<loc>http://ya.ru</loc> '+
-                '</url>\n'+
-              '</urlset>');
-  },
-  'simple sitemap toXML async with two callback arguments': function(beforeExit, assert) {
-    var url = 'http://ya.ru';
-    var ssp = new sm.Sitemap();
-    ssp.add(url);
+    expect(ssp.toString()).toBe(
+      xmlDef +
+                dynamicUrlSet + '\n' +
+                '<url> ' +
+                    xmlLoc +
+                '</url>\n' +
+              '</urlset>')
+  })
+  it('simple sitemap toXML async with two callback arguments', done => {
+    var url = 'http://ya.ru'
+    var ssp = new sm.Sitemap()
+    ssp.add(url)
 
-    ssp.toXML(function(err, xml) {
-      assert.isNull(err);
-      assert.eql(xml,
-                '<?xml version="1.0" encoding="UTF-8"?>\n'+
-                urlset + '\n'+
-                  '<url> '+
-                      '<loc>http://ya.ru</loc> '+
-                  '</url>\n'+
-                '</urlset>');
-    });
-  },
-  'simple sitemap toXML sync': function() {
-    var url = 'http://ya.ru';
-    var ssp = new sm.Sitemap();
-    ssp.add(url);
+    ssp.toXML(function (err, xml) {
+      expect(err).toBe(null)
+      expect(xml).toBe(
+        xmlDef +
+                urlset + '\n' +
+                  '<url> ' +
+                      xmlLoc +
+                  '</url>\n' +
+                '</urlset>')
+      done()
+    })
+  })
+  it('simple sitemap toXML sync', () => {
+    var url = 'http://ya.ru'
+    var ssp = new sm.Sitemap()
+    ssp.add(url)
 
-    assert.eql(ssp.toXML(),
-              '<?xml version="1.0" encoding="UTF-8"?>\n'+
-              urlset + '\n'+
-                '<url> '+
-                    '<loc>http://ya.ru</loc> '+
-                '</url>\n'+
-              '</urlset>');
-  },
-  'simple sitemap toGzip sync': function() {
-    var ssp = new sm.Sitemap();
-    ssp.add('http://ya.ru');
+    expect(ssp.toXML()).toBe(
+      xmlDef +
+              urlset + '\n' +
+                '<url> ' +
+                    xmlLoc +
+                '</url>\n' +
+              '</urlset>')
+  })
+  it('simple sitemap toGzip sync', () => {
+    var ssp = new sm.Sitemap()
+    ssp.add('http://ya.ru')
 
-    assert.eql(ssp.toGzip(), zlib.gzipSync(
-              '<?xml version="1.0" encoding="UTF-8"?>\n'+
-              urlset + '\n'+
-                '<url> '+
-                    '<loc>http://ya.ru</loc> '+
-                '</url>\n'+
+    expect(ssp.toGzip()).toEqual(zlib.gzipSync(
+      xmlDef +
+              urlset + '\n' +
+                '<url> ' +
+                    xmlLoc +
+                '</url>\n' +
               '</urlset>'
-    ));
-  },
-  'simple sitemap toGzip async': function() {
-    var ssp = new sm.Sitemap();
-    ssp.add('http://ya.ru');
+    ))
+  })
+  it('simple sitemap toGzip async', () => {
+    var ssp = new sm.Sitemap()
+    ssp.add('http://ya.ru')
 
-    ssp.toGzip(function(error, result) {
-      assert.eql(error, null);
-      assert.eql(zlib.gunzipSync(result).toString(),
-            '<?xml version="1.0" encoding="UTF-8"?>\n' +
-            urlset + '\n'+
+    ssp.toGzip(function (error, result) {
+      expect(error).toBe(null)
+      expect(zlib.gunzipSync(result).toString()).toBe(
+        xmlDef +
+            urlset + '\n' +
             '<url> ' +
-            '<loc>http://ya.ru</loc> ' +
+            xmlLoc +
             '</url>\n' +
             '</urlset>'
-      );
-    });
-  },
-  'build sitemap index': function() {
-    var expectedResult = '<?xml version="1.0" encoding="UTF-8"?>\n'+
-    '<?xml-stylesheet type="text/xsl" href="https://test.com/style.xsl"?>\n'+
-    '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">\n'+
-    '<sitemap>\n'+
-    '<loc>https://test.com/s1.xml</loc>\n'+
-    '</sitemap>\n'+
-    '<sitemap>\n'+
-    '<loc>https://test.com/s2.xml</loc>\n'+
-    '</sitemap>\n'+
-    '</sitemapindex>';
-
-    var result = sm.buildSitemapIndex({
-      urls: ['https://test.com/s1.xml', 'https://test.com/s2.xml'],
-      xslUrl: 'https://test.com/style.xsl'
-    });
-
-    assert.eql(result, expectedResult);
-  },
-  'build sitemap index with custom xmlNS': function() {
-    var expectedResult = '<?xml version="1.0" encoding="UTF-8"?>\n'+
-    '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'+
-        '<sitemap>\n'+
-            '<loc>https://test.com/s1.xml</loc>\n'+
-        '</sitemap>\n'+
-        '<sitemap>\n'+
-            '<loc>https://test.com/s2.xml</loc>\n'+
-        '</sitemap>\n'+
-    '</sitemapindex>';
-
-    var result = sm.buildSitemapIndex({
-        urls: ['https://test.com/s1.xml', 'https://test.com/s2.xml'],
-        xmlNs: 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"'
-    });
-
-    assert.eql(result, expectedResult);
-  },
-  'simple sitemap index': function() {
-    var tmp = require('os').tmpdir(),
-        url1 = 'http://ya.ru',
-        url2 = 'http://ya2.ru',
-        expectedFiles = [
-          tmp + '/sm-test-0.xml',
-          tmp + '/sm-test-1.xml',
-          tmp + '/sm-test-index.xml'
-        ];
-
-    assert.throws(
-      function() {
-        var ssp = sm.createSitemapIndex({
-          cacheTime: 600000,
-          hostname: 'http://www.sitemap.org',
-          sitemapName: 'sm-test',
-          sitemapSize: 1,
-          targetFolder: '/tmp2',
-          urls: [url1, url2]
-        });
-      },
-      /UndefinedTargetFolder/
-    );
-
-    // Cleanup before run test
-    removeFilesArray(expectedFiles);
-
-    var ssp = sm.createSitemapIndex({
-      cacheTime: 600000,
-      hostname: 'http://www.sitemap.org',
-      sitemapName: 'sm-test',
-      sitemapSize: 1,
-      targetFolder: tmp,
-      urls: [url1, url2],
-      callback: function(err, result) {
-        assert.eql(err, null);
-        assert.eql(result, true);
-        expectedFiles.forEach(function(expectedFile) {
-          assert.eql(fs.existsSync(expectedFile), true);
-        });
-      }
-    });
-  },
-  'sitemap without callback': function() {
-    sm.createSitemapIndex({
-      cacheTime: 600000,
-      hostname: 'http://www.sitemap.org',
-      sitemapName: 'sm-test',
-      sitemapSize: 1,
-      targetFolder: require('os').tmpdir(),
-      urls: ['http://ya.ru', 'http://ya2.ru']
-    });
-  },
-  'sitemap with gzip files': function() {
-    var tmp = require('os').tmpdir(),
-        url1 = 'http://ya.ru',
-        url2 = 'http://ya2.ru',
-        expectedFiles = [
-          tmp + '/sm-test-0.xml.gz',
-          tmp + '/sm-test-1.xml.gz',
-          tmp + '/sm-test-index.xml'
-        ];
-
-    // Cleanup before run test
-    removeFilesArray(expectedFiles);
-
-    sm.createSitemapIndex({
-      cacheTime: 600000,
-      hostname: 'http://www.sitemap.org',
-      sitemapName: 'sm-test',
-      sitemapSize: 1,
-      targetFolder: tmp,
-      gzip: true,
-      urls: [url1, url2],
-      callback: function(err, result) {
-        assert.eql(err, null);
-        assert.eql(result, true);
-        expectedFiles.forEach(function(expectedFile) {
-          assert.eql(fs.existsSync(expectedFile), true);
-        });
-      }
-    });
-  },
-  'lpad test': function() {
-    assert.eql(sm.utils.lpad(5, 2), '05');
-    assert.eql(sm.utils.lpad(6, 2, '-'), '-6');
-  },
-  'distinctValues test': function() {
-    assert.eql(sm.utils.distinctArray([1, 2, 2, 5, 2]), [1, 2, 5]);
-  },
-  'sitemap: hostname, createSitemap': function() {
-    var smap = sm.createSitemap({
-          hostname: 'http://test.com',
-          urls: [
-            { url: '/',         changefreq: 'always', priority: 1 },
-            { url: '/page-1/',  changefreq: 'weekly', priority: 0.3 },
-            { url: '/page-2/',  changefreq: 'daily',  priority: 0.7 },
-            { url: '/page-3/',  changefreq: 'monthly',  priority: 0.2, img: '/image.jpg' },
-            { url: 'http://www.test.com/page-4/',  changefreq: 'never',  priority: 0.8 },
-          ]
-        });
-
-    assert.eql(smap.toString(),
-              '<?xml version="1.0" encoding="UTF-8"?>\n'+
-              urlset + '\n'+
-                '<url> '+
-                    '<loc>http://test.com/</loc> '+
-                    '<changefreq>always</changefreq> '+
-                    '<priority>1.0</priority> '+
-                '</url>\n'+
-                '<url> '+
-                    '<loc>http://test.com/page-1/</loc> '+
-                    '<changefreq>weekly</changefreq> '+
-                    '<priority>0.3</priority> '+
-                '</url>\n'+
-                '<url> '+
-                    '<loc>http://test.com/page-2/</loc> '+
-                    '<changefreq>daily</changefreq> '+
-                    '<priority>0.7</priority> '+
-                '</url>\n'+
-                '<url> '+
-                    '<loc>http://test.com/page-3/</loc> '+
-                    '<changefreq>monthly</changefreq> '+
-                    '<priority>0.2</priority> '+
-                    '<image:image>'+
-                        '<image:loc>http://test.com/image.jpg</image:loc>'+
-                    '</image:image> '+
-                '</url>\n'+
-                '<url> '+
-                    '<loc>http://www.test.com/page-4/</loc> '+
-                    '<changefreq>never</changefreq> '+
-                    '<priority>0.8</priority> '+
-                '</url>\n'+
-              '</urlset>');
-  },
-  'sitemap: invalid changefreq error': function() {
-    assert.throws(
-      function() {
-        sm.createSitemap({
-          hostname: 'http://test.com',
-          urls: [{ url: '/', changefreq: 'allllways'}]
-        }).toString();
-      },
-      /changefreq is invalid/
-    );
-  },
-  'sitemap: invalid priority error': function() {
-    assert.throws(
-      function() {
-        sm.createSitemap({
-          hostname: 'http://test.com',
-          urls: [{ url: '/', priority: 1.1}]
-        }).toString();
-      },
-      /priority is invalid/
-    );
-  },
-  'sitemap: test cache': function() {
-    var smap = sm.createSitemap({
-          hostname: 'http://test.com',
-          cacheTime: 500,  // 0.5 sec
-          urls: [
-            { url: '/page-1/',  changefreq: 'weekly', priority: 0.3 }
-          ]
-        })
-      , xml = '<?xml version="1.0" encoding="UTF-8"?>\n'+
-              urlset + '\n'+
-                '<url> '+
-                    '<loc>http://test.com/page-1/</loc> '+
-                    '<changefreq>weekly</changefreq> '+
-                    '<priority>0.3</priority> '+
-                '</url>\n'+
-              '</urlset>';
-
-    // fill cache
-    assert.eql(smap.toString(), xml);
-    // change urls
-    smap.add('http://test.com/new-page/');
-    // check result from cache (not changed)
-    assert.eql(smap.toString(), xml);
-
-    // check new cache
-    // after cacheTime expired
-    setTimeout( function () {
-      // check new sitemap
-      assert.eql(smap.toString(),
-                '<?xml version="1.0" encoding="UTF-8"?>\n'+
-                urlset + '\n'+
-                  '<url> '+
-                      '<loc>http://test.com/page-1/</loc> '+
-                      '<changefreq>weekly</changefreq> '+
-                      '<priority>0.3</priority> '+
-                  '</url>\n'+
-                  '<url> '+
-                      '<loc>http://test.com/new-page/</loc> '+
-                  '</url>\n'+
-                '</urlset>');
-    }, 1000);
-  },
-  'sitemap: test cache off': function() {
-    var smap = sm.createSitemap({
-          hostname: 'http://test.com',
-          // cacheTime: 0,  // cache disabled
-          urls: [
-            { url: '/page-1/',  changefreq: 'weekly', priority: 0.3 }
-          ]
-        })
-      , xml = '<?xml version="1.0" encoding="UTF-8"?>\n'+
-              urlset + '\n'+
-                '<url> '+
-                    '<loc>http://test.com/page-1/</loc> '+
-                    '<changefreq>weekly</changefreq> '+
-                    '<priority>0.3</priority> '+
-                '</url>\n'+
-              '</urlset>';
-
-    assert.eql(smap.toString(), xml);
-    // change urls
-    smap.add('http://test.com/new-page/');
-    // check result without cache (changed one)
-    assert.eql(smap.toString(),
-              '<?xml version="1.0" encoding="UTF-8"?>\n'+
-              urlset + '\n'+
-                '<url> '+
-                    '<loc>http://test.com/page-1/</loc> '+
-                    '<changefreq>weekly</changefreq> '+
-                    '<priority>0.3</priority> '+
-                '</url>\n'+
-                '<url> '+
-                    '<loc>http://test.com/new-page/</loc> '+
-                '</url>\n'+
-              '</urlset>');
-  },
-  'sitemap: handle urls with "http" in the path': function() {
-    var smap = sm.createSitemap({
-          hostname: 'http://test.com',
-          urls: [
-            { url: '/page-that-mentions-http:-in-the-url/',  changefreq: 'weekly', priority: 0.3 }
-          ]
-        })
-      , xml = '<?xml version="1.0" encoding="UTF-8"?>\n'+
-              urlset + '\n'+
-                '<url> '+
-                    '<loc>http://test.com/page-that-mentions-http:-in-the-url/</loc> '+
-                    '<changefreq>weekly</changefreq> '+
-                    '<priority>0.3</priority> '+
-                '</url>\n'+
-              '</urlset>';
-
-    assert.eql(smap.toString(), xml);
-  },
-  'sitemap: handle urls with "&" in the path': function() {
-    var smap = sm.createSitemap({
-          hostname: 'http://test.com',
-          urls: [
-            { url: '/page-that-mentions-&-in-the-url/',  changefreq: 'weekly', priority: 0.3 }
-          ]
-        })
-      , xml = '<?xml version="1.0" encoding="UTF-8"?>\n'+
-              urlset + '\n'+
-                '<url> '+
-                    '<loc>http://test.com/page-that-mentions-&amp;-in-the-url/</loc> '+
-                    '<changefreq>weekly</changefreq> '+
-                    '<priority>0.3</priority> '+
-                '</url>\n'+
-              '</urlset>';
-
-    assert.eql(smap.toString(), xml);
-  },
-  'sitemap: keep urls that start with http:// or https://': function() {
-    var smap = sm.createSitemap({
-          hostname: 'http://test.com',
-          urls: [
-            { url: 'http://ya.ru/page-1/',  changefreq: 'weekly', priority: 0.3 },
-            { url: 'https://ya.ru/page-2/',  changefreq: 'weekly', priority: 0.3 },
-          ]
-        })
-      , xml = '<?xml version="1.0" encoding="UTF-8"?>\n'+
-                urlset + '\n'+
-                '<url> '+
-                    '<loc>http://ya.ru/page-1/</loc> '+
-                    '<changefreq>weekly</changefreq> '+
-                    '<priority>0.3</priority> '+
-                '</url>\n'+
-                '<url> '+
-                    '<loc>https://ya.ru/page-2/</loc> '+
-                    '<changefreq>weekly</changefreq> '+
-                    '<priority>0.3</priority> '+
-                '</url>\n'+
-              '</urlset>';
-
-    assert.eql(smap.toString(), xml);
-  },
-  'sitemap: del by string': function() {
-    var smap = sm.createSitemap({
-          hostname: 'http://test.com',
-          urls: [
-            { url: 'http://ya.ru/page-1/',  changefreq: 'weekly', priority: 0.3 },
-            { url: 'https://ya.ru/page-2/',  changefreq: 'weekly', priority: 0.3 },
-          ]
-        })
-      , xml = '<?xml version="1.0" encoding="UTF-8"?>\n'+
-              urlset + '\n'+
-                '<url> '+
-                    '<loc>https://ya.ru/page-2/</loc> '+
-                    '<changefreq>weekly</changefreq> '+
-                    '<priority>0.3</priority> '+
-                '</url>\n'+
-              '</urlset>';
-    smap.del('http://ya.ru/page-1/');
-
-    assert.eql(smap.toString(), xml);
-  },
-  'sitemap: del by object': function() {
-    var smap = sm.createSitemap({
-          hostname: 'http://test.com',
-          urls: [
-            { url: 'http://ya.ru/page-1/',  changefreq: 'weekly', priority: 0.3 },
-            { url: 'https://ya.ru/page-2/',  changefreq: 'weekly', priority: 0.3 },
-          ]
-        })
-      , xml = '<?xml version="1.0" encoding="UTF-8"?>\n'+
-              urlset + '\n'+
-                '<url> '+
-                    '<loc>https://ya.ru/page-2/</loc> '+
-                    '<changefreq>weekly</changefreq> '+
-                    '<priority>0.3</priority> '+
-                '</url>\n'+
-              '</urlset>';
-    smap.del({url: 'http://ya.ru/page-1/'});
-
-    assert.eql(smap.toString(), xml);
-  },
-  'test for #27': function() {
-        var staticUrls = ['/', '/terms', '/login']
-        var sitemap = sm.createSitemap({urls: staticUrls});
-        sitemap.add({url: '/details/' + 'url1'});
-
-        var sitemap2 = sm.createSitemap({urls: staticUrls});
-
-        assert.eql(sitemap.urls, ['/', '/terms', '/login', {url: '/details/url1'}]);
-        assert.eql(sitemap2.urls, ['/', '/terms', '/login' ]);
-  },
-  'sitemap: langs': function() {
-    var smap = sm.createSitemap({
-          urls: [
-            { url: 'http://test.com/page-1/',  changefreq: 'weekly', priority: 0.3, links: [
-              { lang: 'en', url: 'http://test.com/page-1/', },
-              { lang: 'ja', url: 'http://test.com/page-1/ja/', },
-            ] },
-          ]
-        });
-    assert.eql(smap.toString(),
-              '<?xml version="1.0" encoding="UTF-8"?>\n'+
-              urlset + '\n'+
-                '<url> '+
-                    '<loc>http://test.com/page-1/</loc> '+
-                    '<changefreq>weekly</changefreq> '+
-                    '<priority>0.3</priority> '+
-                    '<xhtml:link rel="alternate" hreflang="en" href="http://test.com/page-1/" /> '+
-                    '<xhtml:link rel="alternate" hreflang="ja" href="http://test.com/page-1/ja/" /> '+
-                '</url>\n'+
-              '</urlset>');
-  },
-  'sitemap: normalize urls, see #39': function() {
-    ["http://ya.ru", "http://ya.ru/"].forEach(function(hostname){
-      var ssp = new sm.Sitemap(null, hostname);
-      ssp.add("page1");
-      ssp.add("/page2");
-
-      ssp.toXML(function(err, xml) {
-        assert.eql(xml,
-          '<?xml version="1.0" encoding="UTF-8"?>\n'+
-          urlset + '\n'+
-            '<url> '+
-                '<loc>http://ya.ru/page1</loc> '+
-            '</url>\n'+
-            '<url> '+
-                '<loc>http://ya.ru/page2</loc> '+
-            '</url>\n'+
-          '</urlset>');
-      });
+      )
     })
-  },
-  'sitemap: langs with hostname': function() {
-    var smap = sm.createSitemap({
-          hostname: 'http://test.com',
-          urls: [
-            { url: '/page-1/',  changefreq: 'weekly', priority: 0.3, links: [
-              { lang: 'en', url: '/page-1/', },
-              { lang: 'ja', url: '/page-1/ja/', },
-            ] },
-          ]
-        });
-    assert.eql(smap.toString(),
-              '<?xml version="1.0" encoding="UTF-8"?>\n'+
-              urlset + '\n'+
-                '<url> '+
-                    '<loc>http://test.com/page-1/</loc> '+
-                    '<changefreq>weekly</changefreq> '+
-                    '<priority>0.3</priority> '+
-                    '<xhtml:link rel="alternate" hreflang="en" href="http://test.com/page-1/" /> '+
-                    '<xhtml:link rel="alternate" hreflang="ja" href="http://test.com/page-1/ja/" /> '+
-                '</url>\n'+
-              '</urlset>');
-  },
-  'sitemap: error thrown in async-style .toXML()': function() {
-    var smap = sm.createSitemap({
-      hostname: 'http://test.com',
-      urls: [
-        { url: '/page-1/', changefreq: 'weekly', priority: 0.3 }
-      ]
-    });
-    smap.toString = sinon.stub();
-    var error = new Error('Some error happens');
-    smap.toString.throws(error);
-    smap.toXML(function (err, xml) {
-      assert.eql(err, error);
-    });
-  },
-  'sitemap: android app linking': function() {
-    var smap = sm.createSitemap({
-          urls: [
-            { url: 'http://test.com/page-1/',  changefreq: 'weekly', priority: 0.3,
-              androidLink: 'android-app://com.company.test/page-1/' },
-            ]
-          });
-    assert.eql(smap.toString(),
-              '<?xml version="1.0" encoding="UTF-8"?>\n'+
-              urlset + '\n'+
-                '<url> '+
-                  '<loc>http://test.com/page-1/</loc> '+
-                  '<changefreq>weekly</changefreq> '+
-                  '<priority>0.3</priority> '+
-                  '<xhtml:link rel="alternate" href="android-app://com.company.test/page-1/" /> '+
-                '</url>\n'+
-              '</urlset>');
-  },
-  'sitemap: AMP': function() {
-    var smap = sm.createSitemap({
-          urls: [
-            { url: 'http://test.com/page-1/',  changefreq: 'weekly', priority: 0.3,
-              ampLink: 'http://ampproject.org/article.amp.html' },
-            ]
-          });
-    assert.eql(smap.toString(),
-      '<?xml version="1.0" encoding="UTF-8"?>\n'+ urlset + '\n'+
-        '<url> '+
-          '<loc>http://test.com/page-1/</loc> '+
-          '<changefreq>weekly</changefreq> '+
-          '<priority>0.3</priority> '+
-          '<xhtml:link rel="amphtml" href="http://ampproject.org/article.amp.html" />'+
-        '</url>\n'+
-      '</urlset>');
-  },
-  'sitemap: expires': function() {
-    var smap = sm.createSitemap({
-          urls: [
-            { url: 'http://test.com/page-1/',  changefreq: 'weekly', priority: 0.3,
-              expires: new Date('2016-09-13') },
-            ]
-          });
-    assert.eql(smap.toString(),
-      '<?xml version="1.0" encoding="UTF-8"?>\n'+ urlset + '\n'+
-        '<url> '+
-          '<loc>http://test.com/page-1/</loc> '+
-          '<changefreq>weekly</changefreq> '+
-          '<priority>0.3</priority> '+
-          '<expires>2016-09-13T00:00:00.000Z</expires> '+
-        '</url>\n'+
-      '</urlset>');
-  },
-  'sitemap: image with caption': function() {
-    var smap = sm.createSitemap({
-      urls: [
-        { url: 'http://test.com', img: {url: 'http://test.com/image.jpg?param&otherparam', caption: 'Test Caption'}}
-      ]
-    });
-
-    assert.eql(smap.toString(),
-      '<?xml version="1.0" encoding="UTF-8"?>\n'+
-      urlset + '\n'+
-        '<url> '+
-            '<loc>http://test.com</loc> '+
-            '<image:image>'+
-                '<image:loc>http://test.com/image.jpg?param&amp;otherparam</image:loc>'+
-                '<image:caption><![CDATA[Test Caption]]></image:caption>'+
-            '</image:image> '+
-        '</url>\n'+
-      '</urlset>')
-  },
-  'sitemap: image with caption, title, geo_location, license': function() {
-    var smap = sm.createSitemap({
-      urls: [
-        { url: 'http://test.com',
-          img: {
-            url: 'http://test.com/image.jpg',
-            caption: 'Test Caption',
-            title: 'Test title',
-            geoLocation: 'Test Geo Location',
-            license: 'http://test.com/license.txt',
-          }
-        }
-      ]
-    });
-
-    assert.eql(smap.toString(),
-      '<?xml version="1.0" encoding="UTF-8"?>\n'+
-      urlset + '\n'+
-        '<url> '+
-            '<loc>http://test.com</loc> '+
-            '<image:image>'+
-                '<image:loc>http://test.com/image.jpg</image:loc>'+
-                '<image:caption><![CDATA[Test Caption]]></image:caption>'+
-                '<image:geo_location>Test Geo Location</image:geo_location>'+
-                '<image:title><![CDATA[Test title]]></image:title>'+
-                '<image:license>http://test.com/license.txt</image:license>'+
-            '</image:image> '+
-        '</url>\n'+
-      '</urlset>')
-  },
-  'sitemap: images with captions': function() {
-    var smap = sm.createSitemap({
-      urls: [
-        { url: 'http://test.com', img: {url: 'http://test.com/image.jpg', caption: 'Test Caption'}},
-        { url: 'http://test.com/page2/', img: {url: 'http://test.com/image2.jpg', caption: 'Test Caption 2'}}
-      ]
-    });
-
-    assert.eql(smap.toString(),
-      '<?xml version="1.0" encoding="UTF-8"?>\n'+
-      urlset + '\n'+
-        '<url> '+
-            '<loc>http://test.com</loc> '+
-            '<image:image>'+
-                '<image:loc>http://test.com/image.jpg</image:loc>'+
-                '<image:caption><![CDATA[Test Caption]]></image:caption>'+
-            '</image:image> '+
-        '</url>\n'+
-        '<url> '+
-            '<loc>http://test.com/page2/</loc> '+
-            '<image:image>'+
-                '<image:loc>http://test.com/image2.jpg</image:loc>'+
-                '<image:caption><![CDATA[Test Caption 2]]></image:caption>'+
-            '</image:image> '+
-        '</url>\n'+
-      '</urlset>')
-  },
-  'sitemap: images with captions': function() {
-    var smap = sm.createSitemap({
-      hostname: 'http://test.com',
-      urls: [
-        {
-          url: '/index.html',
-          img: [
-            {url: 'http://test.com/image.jpg', caption: 'Test Caption'},
-            {url: 'http://test.com/image2.jpg', caption: 'Test Caption 2'}
-          ]
-        }
-      ]
-    });
-
-    smap.urls.push({url: '/index2.html', img: [{url: '/image3.jpg', caption: 'Test Caption 3'}]});
-
-    assert.eql(smap.toString(),
-      '<?xml version="1.0" encoding="UTF-8"?>\n'+
-      urlset + '\n'+
-        '<url> '+
-            '<loc>http://test.com/index.html</loc> '+
-            '<image:image>'+
-                '<image:loc>http://test.com/image.jpg</image:loc>'+
-                '<image:caption><![CDATA[Test Caption]]></image:caption>'+
-            '</image:image> '+
-            '<image:image>'+
-                '<image:loc>http://test.com/image2.jpg</image:loc>'+
-                '<image:caption><![CDATA[Test Caption 2]]></image:caption>'+
-            '</image:image> '+
-        '</url>\n'+
-        '<url> '+
-            '<loc>http://test.com/index2.html</loc> '+
-            '<image:image>'+
-                '<image:loc>http://test.com/image3.jpg</image:loc>'+
-                '<image:caption><![CDATA[Test Caption 3]]></image:caption>'+
-            '</image:image> '+
-        '</url>\n'+
-      '</urlset>');
-  },
-  'sitemap: video': function() {
+  })
+  it('sitemap: video attributes', () => {
     var smap = sm.createSitemap({
       urls: [
         {
-          "url":"https://roosterteeth.com/episode/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club",
-          "video":[{
-            "title":"2008:E2 - Burnout Paradise: Millionaire's Club",
-            "description":"Jack gives us a walkthrough on getting the Millionaire's Club Achievement in Burnout Paradise.",
-            "player_loc":"https://roosterteeth.com/embed/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club?a&b",
-            "thumbnail_loc":"https://rtv3-img-roosterteeth.akamaized.net/uploads/images/e82e1925-89dd-4493-9bcf-cdef9665d726/sm/ep298.jpg?a&b",
-            "duration":174,
-            "publication_date":"2008-07-29T14:58:04.000Z",
-            "requires_subscription":false
+          'url': 'https://roosterteeth.com/episode/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club',
+          'video': [{
+            'title': "2008:E2 - Burnout Paradise: Millionaire's Club",
+            'description': "Jack gives us a walkthrough on getting the Millionaire's Club Achievement in Burnout Paradise.",
+            'player_loc': 'https://roosterteeth.com/embed/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club',
+            'player_loc:autoplay': 'ap=1',
+            'restriction': 'IE GB US CA',
+            'restriction:relationship': 'allow',
+            'gallery_loc': 'https://roosterteeth.com/series/awhu',
+            'gallery_loc:title': 'awhu series page',
+            'price': '1.99',
+            'price:currency': 'EUR',
+            'price:type': 'rent',
+            'price:resolution': 'HD',
+            'platform': 'WEB',
+            'platform:relationship': 'allow',
+            'thumbnail_loc': 'https://rtv3-img-roosterteeth.akamaized.net/uploads/images/e82e1925-89dd-4493-9bcf-cdef9665d726/sm/ep298.jpg',
+            'duration': 174,
+            'publication_date': '2008-07-29T14:58:04.000Z',
+            'requires_subscription': 'yes'
           }]
         }
       ]
-    });
-
-    assert.eql(smap.toString(),
-      '<?xml version="1.0" encoding="UTF-8"?>\n'+
-      urlset + '\n'+
-        '<url> '+
-            '<loc>https://roosterteeth.com/episode/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club</loc> '+
-            '<video:video>'+
-                '<video:thumbnail_loc>https://rtv3-img-roosterteeth.akamaized.net/uploads/images/e82e1925-89dd-4493-9bcf-cdef9665d726/sm/ep298.jpg?a&amp;b</video:thumbnail_loc>' +
-                '<video:title><![CDATA[2008:E2 - Burnout Paradise: Millionaire\'s Club]]></video:title>' +
-                '<video:description><![CDATA[Jack gives us a walkthrough on getting the Millionaire\'s Club Achievement in Burnout Paradise.]]></video:description>' +
-                '<video:player_loc>https://roosterteeth.com/embed/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club?a&amp;b</video:player_loc>' +
-                '<video:duration>174</video:duration>' +
-                '<video:publication_date>2008-07-29T14:58:04.000Z</video:publication_date>' +
-            '</video:video> ' +
-        '</url>\n'+
-      '</urlset>')
-  },
-  'sitemap: video duration': function() {
-    assert.throws( function() {
-      var smap = new sm.SitemapItem({
-            "url":"https://roosterteeth.com/episode/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club",
-            "video":[{
-              "title":"2008:E2 - Burnout Paradise: Millionaire's Club",
-              "description":"Jack gives us a walkthrough on getting the Millionaire's Club Achievement in Burnout Paradise.",
-              "player_loc":"https://roosterteeth.com/embed/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club",
-              "thumbnail_loc":"https://rtv3-img-roosterteeth.akamaized.net/uploads/images/e82e1925-89dd-4493-9bcf-cdef9665d726/sm/ep298.jpg",
-              "duration": -1,
-              "publication_date":"2008-07-29T14:58:04.000Z",
-              "requires_subscription":false
-            }]
-      });
-      smap.toString()
-    },
-      /duration must be an integer/
-    );
-
-  },
-  'sitemap: video description limit': function() {
-    assert.throws( function() {
-      var smap = new sm.SitemapItem({
-            "url":"https://roosterteeth.com/episode/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club",
-            "video":[{
-              "title":"2008:E2 - Burnout Paradise: Millionaire's Club",
-              "description":"Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue velit cursus nunc, quis gravida magna mi a libero. Fusce vulputate eleifend sapien. Vestibulum purus quam, scelerisque ut, mollis sed, nonummy id, metus. Nullam accumsan lorem in dui. Cras ultricies mi eu turpis hendrerit fringilla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; In ac dui quis mi consectetuer lacinia. Nam pretium turpis et arcu. Duis arcu tortor, suscipit eget, imperdiet nec, imperdiet iaculis, ipsum. Sed aliquam ultrices mauris. Integer ante arcu, accumsan a, consectetuer eget, posuere ut, mauris. Praesent adipiscing. Phasellus ullamcorper ipsum rutrum nunc. Nunc nonummy metus. Vestibulum volutpat pretium libero. Cras id dui. Aenean ut eros et nisl sagittis vestibulum. Nullam nulla.",
-              "player_loc":"https://roosterteeth.com/embed/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club",
-              "thumbnail_loc":"https://rtv3-img-roosterteeth.akamaized.net/uploads/images/e82e1925-89dd-4493-9bcf-cdef9665d726/sm/ep298.jpg",
-              "duration": -1,
-              "publication_date":"2008-07-29T14:58:04.000Z",
-              "requires_subscription":false
-            }]
-      });
-      smap.toString()
-    },
-      /2048 characters/
-    );
-
-  },
-  'sitemap: video attributes': function() {
-    var smap = sm.createSitemap({
-      urls: [
-        {
-          "url":"https://roosterteeth.com/episode/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club",
-          "video":[{
-            "title":"2008:E2 - Burnout Paradise: Millionaire's Club",
-            "description":"Jack gives us a walkthrough on getting the Millionaire's Club Achievement in Burnout Paradise.",
-            "player_loc":"https://roosterteeth.com/embed/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club",
-            "player_loc:autoplay":"ap=1",
-            "restriction": "IE GB US CA",
-            "restriction:relationship": "allow",
-            "gallery_loc": "https://roosterteeth.com/series/awhu",
-            "gallery_loc:title": "awhu series page",
-            "price": "1.99",
-            "price:currency": "EUR",
-            "price:type": "rent",
-            "price:resolution": "HD",
-            "platform": "WEB",
-            "platform:relationship": "allow",
-            "thumbnail_loc":"https://rtv3-img-roosterteeth.akamaized.net/uploads/images/e82e1925-89dd-4493-9bcf-cdef9665d726/sm/ep298.jpg",
-            "duration":174,
-            "publication_date":"2008-07-29T14:58:04.000Z",
-            "requires_subscription": 'yes'
-          }]
-        }
-      ]
-    });
+    })
 
     var result = smap.toString()
-    var expectedResult = '<?xml version="1.0" encoding="UTF-8"?>\n'+
-      urlset + '\n'+
-        '<url> '+
-            '<loc>https://roosterteeth.com/episode/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club</loc> '+
-            '<video:video>'+
+    var expectedResult = xmlDef +
+      urlset + '\n' +
+        '<url> ' +
+            '<loc>https://roosterteeth.com/episode/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club</loc> ' +
+            '<video:video>' +
                 '<video:thumbnail_loc>https://rtv3-img-roosterteeth.akamaized.net/uploads/images/e82e1925-89dd-4493-9bcf-cdef9665d726/sm/ep298.jpg</video:thumbnail_loc>' +
                 '<video:title><![CDATA[2008:E2 - Burnout Paradise: Millionaire\'s Club]]></video:title>' +
                 '<video:description><![CDATA[Jack gives us a walkthrough on getting the Millionaire\'s Club Achievement in Burnout Paradise.]]></video:description>' +
@@ -1020,104 +439,682 @@ module.exports = {
                 '<video:requires_subscription>yes</video:requires_subscription>' +
                 '<video:platform relationship="allow">WEB</video:platform>' +
             '</video:video> ' +
-        '</url>\n'+
-      '</urlset>';
-    assert.eql(result, expectedResult)
+        '</url>\n' +
+      '</urlset>'
+    expect(result).toBe(expectedResult)
+  })
+  it('sitemap: hostname, createSitemap', () => {
+    var smap = sm.createSitemap({
+      hostname: 'http://test.com',
+      urls: [
+        { url: '/', changefreq: 'always', priority: 1 },
+        { url: '/page-1/', changefreq: 'weekly', priority: 0.3 },
+        { url: '/page-2/', changefreq: 'daily', priority: 0.7 },
+        { url: '/page-3/', changefreq: 'monthly', priority: 0.2, img: '/image.jpg' },
+        { url: 'http://www.test.com/page-4/', changefreq: 'never', priority: 0.8 }
+      ]
+    })
 
-  },
-  'sitemap: video price type': function() {
-    assert.throws( function() {
-      var smap = new sm.SitemapItem({
-            "url":"https://roosterteeth.com/episode/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club",
-            "video":[{
-              "title":"2008:E2 - Burnout Paradise: Millionaire's Club",
-              "description":"Lorem ipsum",
-              "player_loc":"https://roosterteeth.com/embed/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club",
-              "thumbnail_loc":"https://rtv3-img-roosterteeth.akamaized.net/uploads/images/e82e1925-89dd-4493-9bcf-cdef9665d726/sm/ep298.jpg",
-              "price": '1.99',
-              "price:type": 'subscription'
-            }]
-      });
-      smap.toString()
-    },
-      /is not a valid value for attr: "price:type"/
-    );
+    expect(smap.toString()).toBe(
+      xmlDef +
+              urlset + '\n' +
+                '<url> ' +
+                    '<loc>http://test.com/</loc> ' +
+                    '<changefreq>always</changefreq> ' +
+                    '<priority>1.0</priority> ' +
+                '</url>\n' +
+                '<url> ' +
+                    '<loc>http://test.com/page-1/</loc> ' +
+                    '<changefreq>weekly</changefreq> ' +
+                    '<priority>0.3</priority> ' +
+                '</url>\n' +
+                '<url> ' +
+                    '<loc>http://test.com/page-2/</loc> ' +
+                    '<changefreq>daily</changefreq> ' +
+                    '<priority>0.7</priority> ' +
+                '</url>\n' +
+                '<url> ' +
+                    '<loc>http://test.com/page-3/</loc> ' +
+                    '<changefreq>monthly</changefreq> ' +
+                    '<priority>0.2</priority> ' +
+                    '<image:image>' +
+                        '<image:loc>http://test.com/image.jpg</image:loc>' +
+                    '</image:image> ' +
+                '</url>\n' +
+                '<url> ' +
+                    '<loc>http://www.test.com/page-4/</loc> ' +
+                    '<changefreq>never</changefreq> ' +
+                    '<priority>0.8</priority> ' +
+                '</url>\n' +
+              '</urlset>')
+  })
+  it('sitemap: invalid changefreq error', () => {
+    expect(
+      function () {
+        sm.createSitemap({
+          hostname: 'http://test.com',
+          urls: [{ url: '/', changefreq: 'allllways' }]
+        }).toString()
+      }
+    ).toThrowError(/changefreq is invalid/)
+  })
+  it('sitemap: invalid priority error', () => {
+    expect(
+      function () {
+        sm.createSitemap({
+          hostname: 'http://test.com',
+          urls: [{ url: '/', priority: 1.1 }]
+        }).toString()
+      }
+    ).toThrowError(/priority is invalid/)
+  })
+  it('sitemap: test cache', () => {
+    const smap = sm.createSitemap({
+      hostname: 'http://test.com',
+      cacheTime: 500, // 0.5 sec
+      urls: [
+        { url: '/page-1/', changefreq: 'weekly', priority: 0.3 }
+      ]
+    })
+    const xml = xmlDef +
+              urlset + '\n' +
+                '<url> ' +
+                    '<loc>http://test.com/page-1/</loc> ' +
+                    '<changefreq>weekly</changefreq> ' +
+                    '<priority>0.3</priority> ' +
+                '</url>\n' +
+              '</urlset>'
 
-  },
-  'sitemap: video price currency': function() {
-    assert.throws( function() {
-      var smap = new sm.SitemapItem({
-            "url":"https://roosterteeth.com/episode/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club",
-            "video":[{
-              "title":"2008:E2 - Burnout Paradise: Millionaire's Club",
-              "description":"Lorem ipsum",
-              "player_loc":"https://roosterteeth.com/embed/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club",
-              "thumbnail_loc":"https://rtv3-img-roosterteeth.akamaized.net/uploads/images/e82e1925-89dd-4493-9bcf-cdef9665d726/sm/ep298.jpg",
-              "price": '1.99',
-              "price:currency": 'dollar'
-            }]
-      });
-      smap.toString()
-    },
-      /is not a valid value for attr: "price:currency"/
-    );
+    // fill cache
+    expect(smap.toString()).toBe(xml)
+    // change urls
+    smap.add('http://test.com/new-page/')
+    // check result from cache (not changed)
+    expect(smap.toString()).toBe(xml)
 
-  },
-  'sitemap: video price resolution': function() {
-    assert.throws( function() {
-      var smap = new sm.SitemapItem({
-            "url":"https://roosterteeth.com/episode/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club",
-            "video":[{
-              "title":"2008:E2 - Burnout Paradise: Millionaire's Club",
-              "description":"Lorem ipsum",
-              "player_loc":"https://roosterteeth.com/embed/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club",
-              "thumbnail_loc":"https://rtv3-img-roosterteeth.akamaized.net/uploads/images/e82e1925-89dd-4493-9bcf-cdef9665d726/sm/ep298.jpg",
-              "price": '1.99',
-              "price:resolution": '1920x1080'
-            }]
-      });
-      smap.toString()
-    },
-      /is not a valid value for attr: "price:resolution"/
-    );
+    // check new cache
+    // after cacheTime expired
+    setTimeout(function () {
+      // check new sitemap
+      expect(smap.toString()).toBe(
+        xmlDef +
+                urlset + '\n' +
+                  '<url> ' +
+                      '<loc>http://test.com/page-1/</loc> ' +
+                      '<changefreq>weekly</changefreq> ' +
+                      '<priority>0.3</priority> ' +
+                  '</url>\n' +
+                  '<url> ' +
+                      '<loc>http://test.com/new-page/</loc> ' +
+                  '</url>\n' +
+                '</urlset>')
+    }, 1000)
+  })
+  it('sitemap: test cache off', () => {
+    const smap = sm.createSitemap({
+      hostname: 'http://test.com',
+      // cacheTime: 0,  // cache disabled
+      urls: [
+        { url: '/page-1/', changefreq: 'weekly', priority: 0.3 }
+      ]
+    })
+    const xml = xmlDef +
+              urlset + '\n' +
+                '<url> ' +
+                    '<loc>http://test.com/page-1/</loc> ' +
+                    '<changefreq>weekly</changefreq> ' +
+                    '<priority>0.3</priority> ' +
+                '</url>\n' +
+              '</urlset>'
 
-  },
-  'sitemap: video platform relationship': function() {
-    assert.throws( function() {
-      var smap = new sm.SitemapItem({
-            "url":"https://roosterteeth.com/episode/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club",
-            "video":[{
-              "title":"2008:E2 - Burnout Paradise: Millionaire's Club",
-              "description":"Lorem ipsum",
-              "player_loc":"https://roosterteeth.com/embed/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club",
-              "thumbnail_loc":"https://rtv3-img-roosterteeth.akamaized.net/uploads/images/e82e1925-89dd-4493-9bcf-cdef9665d726/sm/ep298.jpg",
-              "platform": "tv",
-              "platform:relationship": "mother"
-            }]
-      });
-      smap.toString()
-    },
-      /is not a valid value for attr: "platform:relationship"/
-    );
+    expect(smap.toString()).toBe(xml)
+    // change urls
+    smap.add('http://test.com/new-page/')
+    // check result without cache (changed one)
+    expect(smap.toString()).toBe(
+      xmlDef +
+              urlset + '\n' +
+                '<url> ' +
+                    '<loc>http://test.com/page-1/</loc> ' +
+                    '<changefreq>weekly</changefreq> ' +
+                    '<priority>0.3</priority> ' +
+                '</url>\n' +
+                '<url> ' +
+                    '<loc>http://test.com/new-page/</loc> ' +
+                '</url>\n' +
+              '</urlset>')
+  })
+  it('sitemap: handle urls with "http" in the path', () => {
+    var smap = sm.createSitemap({
+      hostname: 'http://test.com',
+      urls: [
+        { url: '/page-that-mentions-http:-in-the-url/', changefreq: 'weekly', priority: 0.3 }
+      ]
+    })
+    const xml = xmlDef +
+              urlset + '\n' +
+                '<url> ' +
+                    '<loc>http://test.com/page-that-mentions-http:-in-the-url/</loc> ' +
+                    '<changefreq>weekly</changefreq> ' +
+                    '<priority>0.3</priority> ' +
+                '</url>\n' +
+              '</urlset>'
 
-  },
-  'sitemap: video restriction': function() {
-    assert.throws( function() {
-      var smap = new sm.SitemapItem({
-            "url":"https://roosterteeth.com/episode/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club",
-            "video":[{
-              "title":"2008:E2 - Burnout Paradise: Millionaire's Club",
-              "description":"Lorem ipsum",
-              "player_loc":"https://roosterteeth.com/embed/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club",
-              "thumbnail_loc":"https://rtv3-img-roosterteeth.akamaized.net/uploads/images/e82e1925-89dd-4493-9bcf-cdef9665d726/sm/ep298.jpg",
-              "restriction": 'IE GB US CA',
-              "restriction:relationship": 'father'
-            }]
-      });
-      smap.toString()
-    },
-      /is not a valid value for attr: "restriction:relationship"/
-    );
+    expect(smap.toString()).toBe(xml)
+  })
+  it('sitemap: handle urls with "&" in the path', () => {
+    var smap = sm.createSitemap({
+      hostname: 'http://test.com',
+      urls: [
+        { url: '/page-that-mentions-&-in-the-url/', changefreq: 'weekly', priority: 0.3 }
+      ]
+    })
+    const xml = xmlDef +
+              urlset + '\n' +
+                '<url> ' +
+                    '<loc>http://test.com/page-that-mentions-&amp;-in-the-url/</loc> ' +
+                    '<changefreq>weekly</changefreq> ' +
+                    '<priority>0.3</priority> ' +
+                '</url>\n' +
+              '</urlset>'
 
-  }
-}
+    expect(smap.toString()).toBe(xml)
+  })
+  it('sitemap: keep urls that start with http:// or https://', () => {
+    const smap = sm.createSitemap({
+      hostname: 'http://test.com',
+      urls: [
+        { url: 'http://ya.ru/page-1/', changefreq: 'weekly', priority: 0.3 },
+        { url: 'https://ya.ru/page-2/', changefreq: 'weekly', priority: 0.3 }
+      ]
+    })
+    const xml = xmlDef +
+                urlset + '\n' +
+                '<url> ' +
+                    '<loc>http://ya.ru/page-1/</loc> ' +
+                    '<changefreq>weekly</changefreq> ' +
+                    '<priority>0.3</priority> ' +
+                '</url>\n' +
+                '<url> ' +
+                    '<loc>https://ya.ru/page-2/</loc> ' +
+                    '<changefreq>weekly</changefreq> ' +
+                    '<priority>0.3</priority> ' +
+                '</url>\n' +
+              '</urlset>'
+
+    expect(smap.toString()).toBe(xml)
+  })
+  it('sitemap: del by string', () => {
+    const smap = sm.createSitemap({
+      hostname: 'http://test.com',
+      urls: [
+        { url: 'http://ya.ru/page-1/', changefreq: 'weekly', priority: 0.3 },
+        { url: 'https://ya.ru/page-2/', changefreq: 'weekly', priority: 0.3 }
+      ]
+    })
+    const xml = xmlDef +
+              urlset + '\n' +
+                '<url> ' +
+                    '<loc>https://ya.ru/page-2/</loc> ' +
+                    '<changefreq>weekly</changefreq> ' +
+                    '<priority>0.3</priority> ' +
+                '</url>\n' +
+              '</urlset>'
+    smap.del('http://ya.ru/page-1/')
+
+    expect(smap.toString()).toBe(xml)
+  })
+  it('sitemap: del by object', () => {
+    const smap = sm.createSitemap({
+      hostname: 'http://test.com',
+      urls: [
+        { url: 'http://ya.ru/page-1/', changefreq: 'weekly', priority: 0.3 },
+        { url: 'https://ya.ru/page-2/', changefreq: 'weekly', priority: 0.3 }
+      ]
+    })
+    const xml = xmlDef +
+              urlset + '\n' +
+                '<url> ' +
+                    '<loc>https://ya.ru/page-2/</loc> ' +
+                    '<changefreq>weekly</changefreq> ' +
+                    '<priority>0.3</priority> ' +
+                '</url>\n' +
+              '</urlset>'
+    smap.del({url: 'http://ya.ru/page-1/'})
+
+    expect(smap.toString()).toBe(xml)
+  })
+  it('test for #27', () => {
+    var staticUrls = ['/', '/terms', '/login']
+    var sitemap = sm.createSitemap({urls: staticUrls})
+    sitemap.add({url: '/details/' + 'url1'})
+
+    var sitemap2 = sm.createSitemap({urls: staticUrls})
+
+    expect(sitemap.urls).toEqual(['/', '/terms', '/login', {url: '/details/url1'}])
+    expect(sitemap2.urls).toEqual(['/', '/terms', '/login'])
+  })
+  it('sitemap: langs', () => {
+    var smap = sm.createSitemap({
+      urls: [
+        { url: 'http://test.com/page-1/',
+          changefreq: 'weekly',
+          priority: 0.3,
+          links: [
+            { lang: 'en', url: 'http://test.com/page-1/' },
+            { lang: 'ja', url: 'http://test.com/page-1/ja/' }
+          ] }
+      ]
+    })
+    expect(smap.toString()).toBe(
+      xmlDef +
+              urlset + '\n' +
+                '<url> ' +
+                    '<loc>http://test.com/page-1/</loc> ' +
+                    '<changefreq>weekly</changefreq> ' +
+                    '<priority>0.3</priority> ' +
+                    '<xhtml:link rel="alternate" hreflang="en" href="http://test.com/page-1/" /> ' +
+                    '<xhtml:link rel="alternate" hreflang="ja" href="http://test.com/page-1/ja/" /> ' +
+                '</url>\n' +
+              '</urlset>')
+  })
+  it('sitemap: normalize urls, see #39', () => {
+    ['http://ya.ru', 'http://ya.ru/'].forEach(function (hostname) {
+      var ssp = new sm.Sitemap(null, hostname)
+      ssp.add('page1')
+      ssp.add('/page2')
+
+      ssp.toXML(function (err, xml) {
+        if (err) {
+          console.error(err)
+        }
+        expect(xml).toBe(
+          xmlDef +
+          urlset + '\n' +
+            '<url> ' +
+                '<loc>http://ya.ru/page1</loc> ' +
+            '</url>\n' +
+            '<url> ' +
+                '<loc>http://ya.ru/page2</loc> ' +
+            '</url>\n' +
+          '</urlset>')
+      })
+    })
+  })
+  it('sitemap: langs with hostname', () => {
+    var smap = sm.createSitemap({
+      hostname: 'http://test.com',
+      urls: [
+        { url: '/page-1/',
+          changefreq: 'weekly',
+          priority: 0.3,
+          links: [
+            { lang: 'en', url: '/page-1/' },
+            { lang: 'ja', url: '/page-1/ja/' }
+          ] }
+      ]
+    })
+    expect(smap.toString()).toBe(
+      xmlDef +
+              urlset + '\n' +
+                '<url> ' +
+                    '<loc>http://test.com/page-1/</loc> ' +
+                    '<changefreq>weekly</changefreq> ' +
+                    '<priority>0.3</priority> ' +
+                    '<xhtml:link rel="alternate" hreflang="en" href="http://test.com/page-1/" /> ' +
+                    '<xhtml:link rel="alternate" hreflang="ja" href="http://test.com/page-1/ja/" /> ' +
+                '</url>\n' +
+              '</urlset>')
+  })
+  it('sitemap: error thrown in async-style .toXML()', () => {
+    var smap = sm.createSitemap({
+      hostname: 'http://test.com',
+      urls: [
+        { url: '/page-1/', changefreq: 'weekly', priority: 0.3 }
+      ]
+    })
+    var error = new Error('Some error happens')
+    smap.toString = () => { throw error }
+    smap.toXML(function (err, xml) {
+      expect(err).toBe(error)
+    })
+  })
+  it('sitemap: android app linking', () => {
+    var smap = sm.createSitemap({
+      urls: [
+        { url: 'http://test.com/page-1/',
+          changefreq: 'weekly',
+          priority: 0.3,
+          androidLink: 'android-app://com.company.test/page-1/' }
+      ]
+    })
+    expect(smap.toString()).toBe(
+      xmlDef +
+              urlset + '\n' +
+                '<url> ' +
+                  '<loc>http://test.com/page-1/</loc> ' +
+                  '<changefreq>weekly</changefreq> ' +
+                  '<priority>0.3</priority> ' +
+                  '<xhtml:link rel="alternate" href="android-app://com.company.test/page-1/" /> ' +
+                '</url>\n' +
+              '</urlset>')
+  })
+  it('sitemap: AMP', () => {
+    var smap = sm.createSitemap({
+      urls: [
+        { url: 'http://test.com/page-1/',
+          changefreq: 'weekly',
+          priority: 0.3,
+          ampLink: 'http://ampproject.org/article.amp.html' }
+      ]
+    })
+    expect(smap.toString()).toBe(
+      xmlDef + urlset + '\n' +
+        '<url> ' +
+          '<loc>http://test.com/page-1/</loc> ' +
+          '<changefreq>weekly</changefreq> ' +
+          '<priority>0.3</priority> ' +
+          '<xhtml:link rel="amphtml" href="http://ampproject.org/article.amp.html" />' +
+        '</url>\n' +
+      '</urlset>')
+  })
+  it('sitemap: expires', () => {
+    var smap = sm.createSitemap({
+      urls: [
+        { url: 'http://test.com/page-1/',
+          changefreq: 'weekly',
+          priority: 0.3,
+          expires: new Date('2016-09-13') }
+      ]
+    })
+    expect(smap.toString()).toBe(
+      xmlDef + urlset + '\n' +
+        '<url> ' +
+          '<loc>http://test.com/page-1/</loc> ' +
+          '<changefreq>weekly</changefreq> ' +
+          '<priority>0.3</priority> ' +
+          '<expires>2016-09-13T00:00:00.000Z</expires> ' +
+        '</url>\n' +
+      '</urlset>')
+  })
+  it('sitemap: image with caption', () => {
+    var smap = sm.createSitemap({
+      urls: [
+        { url: 'http://test.com', img: {url: 'http://test.com/image.jpg?param&otherparam', caption: 'Test Caption'} }
+      ]
+    })
+
+    expect(smap.toString()).toBe(
+      xmlDef +
+      urlset + '\n' +
+        '<url> ' +
+            '<loc>http://test.com</loc> ' +
+            '<image:image>' +
+                '<image:loc>http://test.com/image.jpg?param&amp;otherparam</image:loc>' +
+                '<image:caption><![CDATA[Test Caption]]></image:caption>' +
+            '</image:image> ' +
+        '</url>\n' +
+      '</urlset>')
+  })
+  it('sitemap: image with caption, title, geo_location, license', () => {
+    var smap = sm.createSitemap({
+      urls: [
+        { url: 'http://test.com',
+          img: {
+            url: 'http://test.com/image.jpg',
+            caption: 'Test Caption',
+            title: 'Test title',
+            geoLocation: 'Test Geo Location',
+            license: 'http://test.com/license.txt'
+          }
+        }
+      ]
+    })
+
+    expect(smap.toString()).toBe(
+      xmlDef +
+      urlset + '\n' +
+        '<url> ' +
+            '<loc>http://test.com</loc> ' +
+            '<image:image>' +
+                '<image:loc>http://test.com/image.jpg</image:loc>' +
+                '<image:caption><![CDATA[Test Caption]]></image:caption>' +
+                '<image:geo_location>Test Geo Location</image:geo_location>' +
+                '<image:title><![CDATA[Test title]]></image:title>' +
+                '<image:license>http://test.com/license.txt</image:license>' +
+            '</image:image> ' +
+        '</url>\n' +
+      '</urlset>')
+  })
+  it('sitemap: images with captions', () => {
+    var smap = sm.createSitemap({
+      urls: [
+        { url: 'http://test.com', img: {url: 'http://test.com/image.jpg', caption: 'Test Caption'} },
+        { url: 'http://test.com/page2/', img: {url: 'http://test.com/image2.jpg', caption: 'Test Caption 2'} }
+      ]
+    })
+
+    expect(smap.toString()).toBe(
+      xmlDef +
+      urlset + '\n' +
+        '<url> ' +
+            '<loc>http://test.com</loc> ' +
+            '<image:image>' +
+                '<image:loc>http://test.com/image.jpg</image:loc>' +
+                '<image:caption><![CDATA[Test Caption]]></image:caption>' +
+            '</image:image> ' +
+        '</url>\n' +
+        '<url> ' +
+            '<loc>http://test.com/page2/</loc> ' +
+            '<image:image>' +
+                '<image:loc>http://test.com/image2.jpg</image:loc>' +
+                '<image:caption><![CDATA[Test Caption 2]]></image:caption>' +
+            '</image:image> ' +
+        '</url>\n' +
+      '</urlset>')
+  })
+  it('sitemap: images with captions add', () => {
+    var smap = sm.createSitemap({
+      hostname: 'http://test.com',
+      urls: [
+        {
+          url: '/index.html',
+          img: [
+            {url: 'http://test.com/image.jpg', caption: 'Test Caption'},
+            {url: 'http://test.com/image2.jpg', caption: 'Test Caption 2'}
+          ]
+        }
+      ]
+    })
+
+    smap.urls.push({url: '/index2.html', img: [{url: '/image3.jpg', caption: 'Test Caption 3'}]})
+
+    expect(smap.toString()).toBe(
+      xmlDef +
+      urlset + '\n' +
+        '<url> ' +
+            '<loc>http://test.com/index.html</loc> ' +
+            '<image:image>' +
+                '<image:loc>http://test.com/image.jpg</image:loc>' +
+                '<image:caption><![CDATA[Test Caption]]></image:caption>' +
+            '</image:image> ' +
+            '<image:image>' +
+                '<image:loc>http://test.com/image2.jpg</image:loc>' +
+                '<image:caption><![CDATA[Test Caption 2]]></image:caption>' +
+            '</image:image> ' +
+        '</url>\n' +
+        '<url> ' +
+            '<loc>http://test.com/index2.html</loc> ' +
+            '<image:image>' +
+                '<image:loc>http://test.com/image3.jpg</image:loc>' +
+                '<image:caption><![CDATA[Test Caption 3]]></image:caption>' +
+            '</image:image> ' +
+        '</url>\n' +
+      '</urlset>')
+  })
+  it('sitemap: video', () => {
+    var smap = sm.createSitemap({
+      urls: [
+        {
+          'url': 'https://roosterteeth.com/episode/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club',
+          'video': [{
+            'title': "2008:E2 - Burnout Paradise: Millionaire's Club",
+            'description': "Jack gives us a walkthrough on getting the Millionaire's Club Achievement in Burnout Paradise.",
+            'player_loc': 'https://roosterteeth.com/embed/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club?a&b',
+            'thumbnail_loc': 'https://rtv3-img-roosterteeth.akamaized.net/uploads/images/e82e1925-89dd-4493-9bcf-cdef9665d726/sm/ep298.jpg?a&b',
+            'duration': 174,
+            'publication_date': '2008-07-29T14:58:04.000Z',
+            'requires_subscription': false
+          }]
+        }
+      ]
+    })
+
+    expect(smap.toString()).toBe(
+      xmlDef +
+      urlset + '\n' +
+        '<url> ' +
+            '<loc>https://roosterteeth.com/episode/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club</loc> ' +
+            '<video:video>' +
+                '<video:thumbnail_loc>https://rtv3-img-roosterteeth.akamaized.net/uploads/images/e82e1925-89dd-4493-9bcf-cdef9665d726/sm/ep298.jpg?a&amp;b</video:thumbnail_loc>' +
+                '<video:title><![CDATA[2008:E2 - Burnout Paradise: Millionaire\'s Club]]></video:title>' +
+                '<video:description><![CDATA[Jack gives us a walkthrough on getting the Millionaire\'s Club Achievement in Burnout Paradise.]]></video:description>' +
+                '<video:player_loc>https://roosterteeth.com/embed/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club?a&amp;b</video:player_loc>' +
+                '<video:duration>174</video:duration>' +
+                '<video:publication_date>2008-07-29T14:58:04.000Z</video:publication_date>' +
+            '</video:video> ' +
+        '</url>\n' +
+      '</urlset>')
+  })
+})
+describe('sitemapIndex', () => {
+  it('build sitemap index', () => {
+    var expectedResult = xmlDef +
+    '<?xml-stylesheet type="text/xsl" href="https://test.com/style.xsl"?>\n' +
+    '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">\n' +
+    '<sitemap>\n' +
+    '<loc>https://test.com/s1.xml</loc>\n' +
+    '</sitemap>\n' +
+    '<sitemap>\n' +
+    '<loc>https://test.com/s2.xml</loc>\n' +
+    '</sitemap>\n' +
+    '</sitemapindex>'
+
+    var result = sm.buildSitemapIndex({
+      urls: ['https://test.com/s1.xml', 'https://test.com/s2.xml'],
+      xslUrl: 'https://test.com/style.xsl'
+    })
+
+    expect(result).toBe(expectedResult)
+  })
+  it('build sitemap index with custom xmlNS', () => {
+    var expectedResult = xmlDef +
+    '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n' +
+        '<sitemap>\n' +
+            '<loc>https://test.com/s1.xml</loc>\n' +
+        '</sitemap>\n' +
+        '<sitemap>\n' +
+            '<loc>https://test.com/s2.xml</loc>\n' +
+        '</sitemap>\n' +
+    '</sitemapindex>'
+
+    var result = sm.buildSitemapIndex({
+      urls: ['https://test.com/s1.xml', 'https://test.com/s2.xml'],
+      xmlNs: 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"'
+    })
+
+    expect(result).toBe(expectedResult)
+  })
+  it('simple sitemap index', () => {
+    const tmp = require('os').tmpdir()
+    const url1 = 'http://ya.ru'
+    const url2 = 'http://ya2.ru'
+    const expectedFiles = [
+      tmp + '/sm-test-0.xml',
+      tmp + '/sm-test-1.xml',
+      tmp + '/sm-test-index.xml'
+    ]
+
+    expect(
+      function () {
+        sm.createSitemapIndex({
+          cacheTime: 600000,
+          hostname: 'http://www.sitemap.org',
+          sitemapName: 'sm-test',
+          sitemapSize: 1,
+          targetFolder: '/tmp2',
+          urls: [url1, url2]
+        })
+      }
+    ).toThrowError(/UndefinedTargetFolder/)
+
+    // Cleanup before run test
+    removeFilesArray(expectedFiles)
+
+    sm.createSitemapIndex({
+      cacheTime: 600000,
+      hostname: 'http://www.sitemap.org',
+      sitemapName: 'sm-test',
+      sitemapSize: 1,
+      targetFolder: tmp,
+      urls: [url1, url2],
+      callback: function (err, result) {
+        expect(err).toBe(null)
+        expect(result).toBe(true)
+        expectedFiles.forEach(function (expectedFile) {
+          expect(fs.existsSync(expectedFile)).toBe(true)
+        })
+      }
+    })
+  })
+  it('sitemap without callback', () => {
+    sm.createSitemapIndex({
+      cacheTime: 600000,
+      hostname: 'http://www.sitemap.org',
+      sitemapName: 'sm-test',
+      sitemapSize: 1,
+      targetFolder: require('os').tmpdir(),
+      urls: ['http://ya.ru', 'http://ya2.ru']
+    })
+  })
+  it('sitemap with gzip files', () => {
+    const tmp = require('os').tmpdir()
+    const url1 = 'http://ya.ru'
+    const url2 = 'http://ya2.ru'
+    const expectedFiles = [
+      tmp + '/sm-test-0.xml.gz',
+      tmp + '/sm-test-1.xml.gz',
+      tmp + '/sm-test-index.xml'
+    ]
+
+    // Cleanup before run test
+    removeFilesArray(expectedFiles)
+
+    sm.createSitemapIndex({
+      cacheTime: 600000,
+      hostname: 'http://www.sitemap.org',
+      sitemapName: 'sm-test',
+      sitemapSize: 1,
+      targetFolder: tmp,
+      gzip: true,
+      urls: [url1, url2],
+      callback: function (err, result) {
+        expect(err).toBe(null)
+        expect(result).toBe(true)
+        expectedFiles.forEach(function (expectedFile) {
+          expect(fs.existsSync(expectedFile)).toBe(true)
+        })
+      }
+    })
+  })
+})
+
+describe('utils', () => {
+  it('lpad test', () => {
+    expect(sm.utils.lpad(5, 2)).toBe('05')
+    expect(sm.utils.lpad(6, 2, '-')).toBe('-6')
+  })
+  it('distinctValues test', () => {
+    expect(sm.utils.distinctArray([1, 2, 2, 5, 2])).toEqual(['1', '2', '5'])
+  })
+})


### PR DESCRIPTION
This PR:
1. swaps the now unmaintained expresso with jasmine
2. adds coverage reporting via istanbul (npm run coverage on mac)
3. removes some dev dependencies.
4. Adds license to package.json (copied from GH license)
5. Officially specifies node engine support to match those officially supported by nodejs. Note: node 4 was dropped as of Apr. 30.

Jasmine was swapped in as expresso tended to give errors with cut off comparisons forcing me to go in and manually console.log out in order to find out what I broke. Swapping in jasmine also allowed an easy way to plugin coverage reporting to see where we lacked tests.

I've also added an editor config file and some standardjs config options to help with code consistency and correctness going forward (if this is a problem I can remove)

Sample code coverage report
![](https://user-images.githubusercontent.com/1011092/39977747-e4dfdf5c-56f0-11e8-9a22-2ade2129eee4.png)
