### PR TITLE
Ignore more files in the npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,8 @@
 tests/
 node_modules/
 env/
+coverage/
 Makefile
 *.swp
+.editorconfig
+.travis.yml


### PR DESCRIPTION
I noticed a couple of files are getting bundled that aren't needed, let's ignore them.