### PR TITLE
Use CDATA for 'news:name' and 'news:title'

### DIFF
--- a/lib/sitemap-item.js
+++ b/lib/sitemap-item.js
@@ -293,7 +293,7 @@ SitemapItem.prototype.buildXML = function () {
       if (this[p].publication) {
         var publication = newsitem.element('news:publication')
         if (this[p].publication.name) {
-          publication.element('news:name', this[p].publication.name)
+          publication.element('news:name').cdata(this[p].publication.name)
         }
         if (this[p].publication.language) {
           publication.element('news:language', this[p].publication.language)
@@ -315,7 +315,7 @@ SitemapItem.prototype.buildXML = function () {
       }
 
       newsitem.element('news:publication_date', this[p].publication_date)
-      newsitem.element('news:title', this[p].title)
+      newsitem.element('news:title').cdata(this[p].title)
 
       if (this[p].keywords) {
         newsitem.element('news:keywords', this[p].keywords)

--- a/tests/sitemap.test.js
+++ b/tests/sitemap.test.js
@@ -685,7 +685,7 @@ describe('sitemapItem', () => {
     it('matches the example from google', () => {
       var smi = new sm.SitemapItem(news)
 
-      expect(smi.toString()).toBe(`<url><loc>${news.url}</loc><news:news><news:publication><news:name>${news.news.publication.name}</news:name><news:language>${news.news.publication.language}</news:language></news:publication><news:genres>${news.news.genres}</news:genres><news:publication_date>${news.news.publication_date}</news:publication_date><news:title>${news.news.title}</news:title><news:keywords>${news.news.keywords}</news:keywords><news:stock_tickers>${news.news.stock_tickers}</news:stock_tickers></news:news></url>`)
+      expect(smi.toString()).toBe(`<url><loc>${news.url}</loc><news:news><news:publication><news:name><![CDATA[${news.news.publication.name}]]></news:name><news:language>${news.news.publication.language}</news:language></news:publication><news:genres>${news.news.genres}</news:genres><news:publication_date>${news.news.publication_date}</news:publication_date><news:title><![CDATA[${news.news.title}]]></news:title><news:keywords>${news.news.keywords}</news:keywords><news:stock_tickers>${news.news.stock_tickers}</news:stock_tickers></news:news></url>`)
     })
 
     it('can render with only the required params', () => {
@@ -694,7 +694,7 @@ describe('sitemapItem', () => {
       delete news.news.stock_tickers
       var smi = new sm.SitemapItem(news)
 
-      expect(smi.toString()).toBe(`<url><loc>${news.url}</loc><news:news><news:publication><news:name>${news.news.publication.name}</news:name><news:language>${news.news.publication.language}</news:language></news:publication><news:publication_date>${news.news.publication_date}</news:publication_date><news:title>${news.news.title}</news:title></news:news></url>`)
+      expect(smi.toString()).toBe(`<url><loc>${news.url}</loc><news:news><news:publication><news:name><![CDATA[${news.news.publication.name}]]></news:name><news:language>${news.news.publication.language}</news:language></news:publication><news:publication_date>${news.news.publication_date}</news:publication_date><news:title><![CDATA[${news.news.title}]]></news:title></news:news></url>`)
     })
 
     it('will throw if you dont provide required attr publication', () => {

--- a/tests/sitemap.test.js
+++ b/tests/sitemap.test.js
@@ -755,10 +755,10 @@ describe('sitemapItem', () => {
       news.news.access = 'Registration'
       var smi = new sm.SitemapItem(news)
 
-      expect(smi.toString()).toBe(`<url><loc>${news.url}</loc><news:news><news:publication><news:name>${news.news.publication.name}</news:name><news:language>${news.news.publication.language}</news:language></news:publication><news:access>${news.news.access}</news:access><news:genres>${news.news.genres}</news:genres><news:publication_date>${news.news.publication_date}</news:publication_date><news:title>${news.news.title}</news:title><news:keywords>${news.news.keywords}</news:keywords><news:stock_tickers>${news.news.stock_tickers}</news:stock_tickers></news:news></url>`)
+      expect(smi.toString()).toBe(`<url><loc>${news.url}</loc><news:news><news:publication><news:name><![CDATA[${news.news.publication.name}]]></news:name><news:language>${news.news.publication.language}</news:language></news:publication><news:access>${news.news.access}</news:access><news:genres>${news.news.genres}</news:genres><news:publication_date>${news.news.publication_date}</news:publication_date><news:title><![CDATA[${news.news.title}]]></news:title><news:keywords>${news.news.keywords}</news:keywords><news:stock_tickers>${news.news.stock_tickers}</news:stock_tickers></news:news></url>`)
       news.news.access = 'Subscription'
       smi = new sm.SitemapItem(news)
-      expect(smi.toString()).toBe(`<url><loc>${news.url}</loc><news:news><news:publication><news:name>${news.news.publication.name}</news:name><news:language>${news.news.publication.language}</news:language></news:publication><news:access>${news.news.access}</news:access><news:genres>${news.news.genres}</news:genres><news:publication_date>${news.news.publication_date}</news:publication_date><news:title>${news.news.title}</news:title><news:keywords>${news.news.keywords}</news:keywords><news:stock_tickers>${news.news.stock_tickers}</news:stock_tickers></news:news></url>`)
+      expect(smi.toString()).toBe(`<url><loc>${news.url}</loc><news:news><news:publication><news:name><![CDATA[${news.news.publication.name}]]></news:name><news:language>${news.news.publication.language}</news:language></news:publication><news:access>${news.news.access}</news:access><news:genres>${news.news.genres}</news:genres><news:publication_date>${news.news.publication_date}</news:publication_date><news:title><![CDATA[${news.news.title}]]></news:title><news:keywords>${news.news.keywords}</news:keywords><news:stock_tickers>${news.news.stock_tickers}</news:stock_tickers></news:news></url>`)
     })
   })
 })


### PR DESCRIPTION
`news:name` and `news:title` may contain a `&` char. This would broke the XML.
So better use CDATA.