### PR TITLE
Fix package.josn to work with npm 5 and 6 when using engine-strict=true

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "stats-lite": "^2.1.1"
   },
   "engines": {
-    "npm": "^4.0.0",
+    "npm": ">=4.0.0",
     "node": ">=6.0.0"
   },
   "standard": {


### PR DESCRIPTION
I was eager to try out 2.0 in our build, but it currently doesn't work with `engine-strict=true` due to an overly strict engine check. Let's fix that!

@ekalinin Could you tag a patch release after merging this? 🙏 