### PR TITLE
Use HTTPS instead of HTTP

### DIFF
--- a/lib/sitemap-item.js
+++ b/lib/sitemap-item.js
@@ -85,7 +85,7 @@ class SitemapItem {
 
     // How frequently the page is likely to change
     // due to this field is optional no default value is set
-    // please see: http://www.sitemaps.org/protocol.html
+    // please see: https://www.sitemaps.org/protocol.html
     this.changefreq = conf.changefreq
     if (!isSafeUrl && this.changefreq) {
       if (['always', 'hourly', 'daily', 'weekly', 'monthly',
@@ -96,7 +96,7 @@ class SitemapItem {
 
     // The priority of this URL relative to other URLs
     // due to this field is optional no default value is set
-    // please see: http://www.sitemaps.org/protocol.html
+    // please see: https://www.sitemaps.org/protocol.html
     this.priority = conf.priority
     if (!isSafeUrl && this.priority) {
       if (!(this.priority >= 0.0 && this.priority <= 1.0) || typeof this.priority !== 'number') {

--- a/lib/sitemap.js
+++ b/lib/sitemap.js
@@ -41,7 +41,7 @@ class Sitemap {
    */
   constructor(urls, hostname, cacheTime, xslUrl, xmlNs) {
     // This limit is defined by Google. See:
-    // http://sitemaps.org/protocol.php#index
+    // https://sitemaps.org/protocol.php#index
     this.limit = 50000
 
     // Base domain
@@ -165,12 +165,12 @@ class Sitemap {
       this.root.children = []
     }
     if (!this.xmlNs) {
-      this.root.att('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9')
-      this.root.att('xmlns:news', 'http://www.google.com/schemas/sitemap-news/0.9')
-      this.root.att('xmlns:xhtml', 'http://www.w3.org/1999/xhtml')
-      this.root.att('xmlns:mobile', 'http://www.google.com/schemas/sitemap-mobile/1.0')
-      this.root.att('xmlns:image', 'http://www.google.com/schemas/sitemap-image/1.1')
-      this.root.att('xmlns:video', 'http://www.google.com/schemas/sitemap-video/1.1')
+      this.root.att('xmlns', 'https://www.sitemaps.org/schemas/sitemap/0.9')
+      this.root.att('xmlns:news', 'https://www.google.com/schemas/sitemap-news/0.9')
+      this.root.att('xmlns:xhtml', 'https://www.w3.org/1999/xhtml')
+      this.root.att('xmlns:mobile', 'https://www.google.com/schemas/sitemap-mobile/1.0')
+      this.root.att('xmlns:image', 'https://www.google.com/schemas/sitemap-image/1.1')
+      this.root.att('xmlns:video', 'https://www.google.com/schemas/sitemap-video/1.1')
     }
 
     if (this.xslUrl) {
@@ -278,10 +278,10 @@ function buildSitemapIndex (conf) {
     xml.push('<?xml-stylesheet type="text/xsl" href="' + conf.xslUrl + '"?>');
   }
   if (!conf.xmlNs) {
-    xml.push('<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" ' +
-      'xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" ' +
-      'xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" ' +
-      'xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">');
+    xml.push('<sitemapindex xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" ' +
+      'xmlns:mobile="https://www.google.com/schemas/sitemap-mobile/1.0" ' +
+      'xmlns:image="https://www.google.com/schemas/sitemap-image/1.1" ' +
+      'xmlns:video="https://www.google.com/schemas/sitemap-video/1.1">');
   } else {
     xml.push('<sitemapindex ' + conf.xmlNs + '>')
   }
@@ -335,7 +335,7 @@ class SitemapIndex {
     }
 
     // This limit is defined by Google. See:
-    // http://sitemaps.org/protocol.php#index
+    // https://sitemaps.org/protocol.php#index
     this.sitemapSize = sitemapSize;
 
     this.xslUrl = xslUrl;

--- a/tests/sitemap.test.js
+++ b/tests/sitemap.test.js
@@ -10,14 +10,14 @@ const {getTimestampFromDate} = require('../lib/utils.js')
 const fs = require('fs')
 const zlib = require('zlib')
 
-const urlset = '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" ' +
-             'xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" ' +
-             'xmlns:xhtml="http://www.w3.org/1999/xhtml" ' +
-             'xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" ' +
-             'xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" ' +
-             'xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">'
+const urlset = '<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" ' +
+             'xmlns:news="https://www.google.com/schemas/sitemap-news/0.9" ' +
+             'xmlns:xhtml="https://www.w3.org/1999/xhtml" ' +
+             'xmlns:mobile="https://www.google.com/schemas/sitemap-mobile/1.0" ' +
+             'xmlns:image="https://www.google.com/schemas/sitemap-image/1.1" ' +
+             'xmlns:video="https://www.google.com/schemas/sitemap-video/1.1">'
 
-const dynamicUrlSet = '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+const dynamicUrlSet = '<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">'
 const xmlDef = '<?xml version="1.0" encoding="UTF-8"?>'
 const xmlPriority = '<priority>0.9</priority>'
 const xmlLoc = '<loc>http://ya.ru</loc>'
@@ -801,7 +801,7 @@ describe('sitemap', () => {
   it('simple sitemap with dynamic xmlNs', () => {
     var url = 'http://ya.ru'
     var ssp = sm.createSitemap({
-      xmlNs: 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"'
+      xmlNs: 'xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"'
     })
     ssp.add(url)
 


### PR DESCRIPTION
Use https protocol instead of http. I don't know if HTTP this will cause problems with google or other search engines. But google chrome seems to have problems with displaying this XML sitemap when the protocol is not HTTPS so I changed it and it worked great again.