### PR TITLE
Allow 'type' attribute on mobile element

### DIFF
--- a/lib/sitemap-item.js
+++ b/lib/sitemap-item.js
@@ -271,7 +271,10 @@ class SitemapItem {
       } else if (this[p] && p === 'androidLink') {
         this.url.element('xhtml:link', {rel: 'alternate', href: this[p]})
       } else if (this[p] && p === 'mobile') {
-        this.url.element('mobile:mobile')
+        const mobileitem = this.url.element('mobile:mobile')
+        if (typeof this[p] === 'string') {
+          mobileitem.att('type', this[p])
+        }
       } else if (p === 'priority' && (this[p] >= 0.0 && this[p] <= 1.0)) {
         this.url.element(p, parseFloat(this[p]).toFixed(1))
       } else if (this[p] && p === 'ampLink') {

--- a/tests/sitemap.test.js
+++ b/tests/sitemap.test.js
@@ -81,6 +81,20 @@ describe('sitemapItem', () => {
       '</url>')
   })
 
+  it('mobile with type', () => {
+    const url = 'http://ya.ru'
+    const smi = new sm.SitemapItem({
+      'url': url,
+      'mobile': 'pc,mobile'
+    })
+
+    expect(smi.toString()).toBe(
+      '<url>' +
+        xmlLoc +
+        '<mobile:mobile type="pc,mobile"/>' +
+      '</url>')
+  });
+
   it('lastmodISO', () => {
     const url = 'http://ya.ru'
     const smi = new sm.SitemapItem({


### PR DESCRIPTION
Some Search Engine such as **Baidu** (China) recommends to add an element:
`<mobile:mobile type="pc mobile"/>` to the sitemap item to inform that a page is _responsive_: 

See https://jingyan.baidu.com/article/0aa223757a3bfd88cd0d645d.html

The mobile namespace to use then is: `xmlns:mobile="http://www.baidu.com/schemas/sitemap-mobile/1/"`.

Customizing the root namespaces can already be achieved with the `xmlNs` option — but adding a "type" attribute on the `mobile` element can not be done yet.

This PR make it possible to pass a string to the mobile option.

```js
const sitemap = sm.createSitemap ({
  hostname: 'http://example.com',
  urls: [
    { url: '/page-1/',  changefreq: 'daily', priority: 0.3, mobile: 'mobile' },
    { url: '/page-2/',  changefreq: 'monthly',  priority: 0.7, mobile: 'pc,mobile' },
  ],
  xmlNs: [
    'xmlns=http://www.sitemaps.org/schemas/sitemap/0.9',
    'xmlns:xhtml=http://www.w3.org/1999/xhtml',
    'xmlns:mobile=http://www.baidu.com/schemas/sitemap-mobile/1/',
  ].join(' '),
});
```