### PR TITLE
fix(#110): handle multiple video tags

### DIFF
--- a/lib/sitemap-item.js
+++ b/lib/sitemap-item.js
@@ -2,6 +2,8 @@ const ut = require('./utils')
 const fs = require('fs')
 const err = require('./errors')
 const builder = require('xmlbuilder')
+const { isArray } = require('lodash/isArray')
+
 function safeDuration (duration) {
   if (duration < 0 || duration > 28800) {
     throw new err.InvalidVideoDuration()
@@ -163,7 +165,7 @@ class SitemapItem {
       videoxml.element('video:family_friendly', video.family_friendly)
     }
     if (video.tag) {
-      if (!_.isArray(video.tag)) {
+      if (!isArray(video.tag)) {
         videoxml.element('video:tag', video.tag)
       } else {
         for (const tag of video.tag) {

--- a/lib/sitemap-item.js
+++ b/lib/sitemap-item.js
@@ -2,7 +2,7 @@ const ut = require('./utils')
 const fs = require('fs')
 const err = require('./errors')
 const builder = require('xmlbuilder')
-const { isArray } = require('lodash/isArray')
+const isArray = require('lodash/isArray')
 
 function safeDuration (duration) {
   if (duration < 0 || duration > 28800) {

--- a/lib/sitemap-item.js
+++ b/lib/sitemap-item.js
@@ -163,7 +163,7 @@ class SitemapItem {
       videoxml.element('video:family_friendly', video.family_friendly)
     }
     if (video.tag) {
-      if (typeof video.tag.length === 'undefined') {
+      if (!_.isArray(video.tag)) {
         videoxml.element('video:tag', video.tag)
       } else {
         for (const tag of video.tag) {

--- a/lib/sitemap-item.js
+++ b/lib/sitemap-item.js
@@ -163,7 +163,13 @@ class SitemapItem {
       videoxml.element('video:family_friendly', video.family_friendly)
     }
     if (video.tag) {
-      videoxml.element('video:tag', video.tag)
+      if (typeof video.tag.length === 'undefined') {
+        videoxml.element('video:tag', video.tag)
+      } else {
+        for (const tag of video.tag) {
+          videoxml.element('video:tag', tag)
+        }
+      }
     }
     if (video.category) {
       videoxml.element('video:category', video.category)

--- a/tests/sitemap.test.js
+++ b/tests/sitemap.test.js
@@ -601,6 +601,31 @@ describe('sitemapItem', () => {
       expect(result).toBe(expectedResult)
     })
 
+    it('supports array of tags', () => {
+      testvideo.video.tag = ['steak', 'fries']
+      var smap = new sm.SitemapItem(testvideo)
+
+      var result = smap.toString()
+      var expectedResult = '<url>' +
+        '<loc>https://roosterteeth.com/episode/achievement-hunter-achievement-hunter-burnout-paradise-millionaires-club</loc>' +
+        '<video:video>' +
+          thumbnailLoc +
+          title +
+          description +
+          playerLoc +
+          duration +
+          publicationDate +
+          '<video:tag>steak</video:tag><video:tag>fries</video:tag>' +
+          restriction +
+          galleryLoc +
+          price +
+          requiresSubscription +
+          platform +
+        '</video:video>' +
+      '</url>'
+      expect(result).toBe(expectedResult)
+    })
+
     it('supports category', () => {
       testvideo.video.category = 'Baking'
       var smap = new sm.SitemapItem(testvideo)


### PR DESCRIPTION
Related issue : https://github.com/ekalinin/sitemap.js/issues/110.

I suggest to squash the commits, as I tried multiple times to make the tests pass (I couldn't set up the tests locally).