### PR TITLE
bump to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.1.0
+ - fixes #187, #188 typescript errors
+ - adds support for full precision priority #176
 # 3.0.0
  - Converted project to typescript
  - properly encode URLs #179

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sitemap",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Sitemap-generating framework",
   "keywords": [
     "sitemap",


### PR DESCRIPTION
# 3.1.0
 - fixes #187, #188 typescript errors
 - adds support for full precision priority #176

changes: https://github.com/ekalinin/sitemap.js/compare/3.0.0...4e19000