### PR TITLE
Fix sitemap index namespaces

### DIFF
--- a/lib/sitemap-index.ts
+++ b/lib/sitemap-index.ts
@@ -67,10 +67,10 @@ export function buildSitemapIndex (conf: {
     xml.push('<?xml-stylesheet type="text/xsl" href="' + conf.xslUrl + '"?>');
   }
   if (!conf.xmlNs) {
-    xml.push('<sitemapindex xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" ' +
-      'xmlns:mobile="https://www.google.com/schemas/sitemap-mobile/1.0" ' +
-      'xmlns:image="https://www.google.com/schemas/sitemap-image/1.1" ' +
-      'xmlns:video="https://www.google.com/schemas/sitemap-video/1.1">');
+    xml.push('<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" ' +
+      'xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" ' +
+      'xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" ' +
+      'xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">');
   } else {
     xml.push('<sitemapindex ' + conf.xmlNs + '>')
   }


### PR DESCRIPTION
Recently I was creating index sitemap using your library.
```javascript
let sitemapIndex = sm.buildSitemapIndex({
    urls: urls,
});
```
Unfortunately created sitemap is incorrect according to Google Search Console.
It says that namespaces are incorrect.

I have fixed an error by removing **_s_** from **_https_** in namespaces in sitemap index builder method. We have to remember that namespace is a namespace and not an address like it looks like.