### PR TITLE
sitemap index lastmod fixes/improvements

### DIFF
--- a/lib/sitemap-index.ts
+++ b/lib/sitemap-index.ts
@@ -68,7 +68,7 @@ export function buildSitemapIndex (conf: {
   }
 
   if (!conf.xmlNs) {
-    conf.xmlNs = 'xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"'
+    conf.xmlNs = 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"'
   }
 
   const ns = conf.xmlNs.split(' ')

--- a/lib/sitemap-index.ts
+++ b/lib/sitemap-index.ts
@@ -68,10 +68,7 @@ export function buildSitemapIndex (conf: {
   }
 
   if (!conf.xmlNs) {
-    conf.xmlNs = 'xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" ' +
-      'xmlns:mobile="https://www.google.com/schemas/sitemap-mobile/1.0" ' +
-      'xmlns:image="https://www.google.com/schemas/sitemap-image/1.1" ' +
-      'xmlns:video="https://www.google.com/schemas/sitemap-video/1.1"'
+    conf.xmlNs = 'xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"'
   }
 
   const ns = conf.xmlNs.split(' ')

--- a/lib/sitemap-index.ts
+++ b/lib/sitemap-index.ts
@@ -1,4 +1,5 @@
 import { statSync, createWriteStream } from 'fs';
+import { create, XMLElement } from 'xmlbuilder';
 import { Sitemap, createSitemap } from './sitemap'
 import { ICallback } from './types';
 import { UndefinedTargetFolder } from './errors';
@@ -59,20 +60,24 @@ export function buildSitemapIndex (conf: {
   lastmodrealtime?: boolean;
   lastmod?: number | string;
 }): string {
-  let xml = [];
+  const root = create('sitemapindex', {encoding: 'UTF-8'});
   let lastmod = '';
 
-  xml.push('<?xml version="1.0" encoding="UTF-8"?>');
   if (conf.xslUrl) {
-    xml.push('<?xml-stylesheet type="text/xsl" href="' + conf.xslUrl + '"?>');
+    root.instructionBefore('xml-stylesheet', `type="text/xsl" href="${conf.xslUrl}"`);
   }
+
   if (!conf.xmlNs) {
-    xml.push('<sitemapindex xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" ' +
+    conf.xmlNs = 'xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" ' +
       'xmlns:mobile="https://www.google.com/schemas/sitemap-mobile/1.0" ' +
       'xmlns:image="https://www.google.com/schemas/sitemap-image/1.1" ' +
-      'xmlns:video="https://www.google.com/schemas/sitemap-video/1.1">');
-  } else {
-    xml.push('<sitemapindex ' + conf.xmlNs + '>')
+      'xmlns:video="https://www.google.com/schemas/sitemap-video/1.1"'
+  }
+
+  const ns = conf.xmlNs.split(' ')
+  for (let attr of ns) {
+    const [k, v] = attr.split('=')
+    root.attribute(k, v.replace(/^['"]|['"]$/g, ''))
   }
 
   if (conf.lastmodISO) {
@@ -85,22 +90,24 @@ export function buildSitemapIndex (conf: {
 
 
   conf.urls.forEach((url): void => {
+    let lm = lastmod
     if (url instanceof Object && url.url) {
-      lastmod = url.lastmod ? url.lastmod : lastmod;
+      if (url.lastmod) {
+        lm = url.lastmod
+      } else if (url.lastmodISO) {
+        lm = url.lastmodISO
+      }
 
       url = url.url;
     }
-    xml.push('<sitemap>');
-    xml.push('<loc>' + url + '</loc>');
-    if (lastmod) {
-      xml.push('<lastmod>' + lastmod + '</lastmod>');
+    const sm = root.element('sitemap');
+    sm.element('loc', url);
+    if (lm) {
+      sm.element('lastmod', lm);
     }
-    xml.push('</sitemap>');
   });
 
-  xml.push('</sitemapindex>');
-
-  return xml.join('\n');
+  return root.end();
 }
 
 /**

--- a/lib/sitemap.ts
+++ b/lib/sitemap.ts
@@ -192,12 +192,12 @@ export class Sitemap {
       this.root.children = []
     }
     if (!this.xmlNs) {
-      this.root.att('xmlns', 'https://www.sitemaps.org/schemas/sitemap/0.9')
-      this.root.att('xmlns:news', 'https://www.google.com/schemas/sitemap-news/0.9')
-      this.root.att('xmlns:xhtml', 'https://www.w3.org/1999/xhtml')
-      this.root.att('xmlns:mobile', 'https://www.google.com/schemas/sitemap-mobile/1.0')
-      this.root.att('xmlns:image', 'https://www.google.com/schemas/sitemap-image/1.1')
-      this.root.att('xmlns:video', 'https://www.google.com/schemas/sitemap-video/1.1')
+      this.root.att('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9')
+      this.root.att('xmlns:news', 'http://www.google.com/schemas/sitemap-news/0.9')
+      this.root.att('xmlns:xhtml', 'http://www.w3.org/1999/xhtml')
+      this.root.att('xmlns:mobile', 'http://www.google.com/schemas/sitemap-mobile/1.0')
+      this.root.att('xmlns:image', 'http://www.google.com/schemas/sitemap-image/1.1')
+      this.root.att('xmlns:video', 'http://www.google.com/schemas/sitemap-video/1.1')
     }
 
     if (this.xslUrl) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sitemap",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tests/sitemap-index.test.ts
+++ b/tests/sitemap-index.test.ts
@@ -18,7 +18,7 @@ describe('sitemapIndex', () => {
   it('build sitemap index', () => {
     var expectedResult = xmlDef +
     '<?xml-stylesheet type="text/xsl" href="https://test.com/style.xsl"?>' +
-    '<sitemapindex xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">' +
+    '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' +
     '<sitemap>' +
     '<loc>https://test.com/s1.xml</loc>' +
     '</sitemap>' +
@@ -36,7 +36,7 @@ describe('sitemapIndex', () => {
   })
   it('build sitemap index with custom xmlNS', () => {
     var expectedResult = xmlDef +
-    '<sitemapindex xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">' +
+    '<sitemapindex xmlns="http://www.example.org/schemas/sitemap/0.9">' +
         '<sitemap>' +
             '<loc>https://test.com/s1.xml</loc>' +
         '</sitemap>' +
@@ -47,14 +47,14 @@ describe('sitemapIndex', () => {
 
     var result = sm.buildSitemapIndex({
       urls: ['https://test.com/s1.xml', 'https://test.com/s2.xml'],
-      xmlNs: 'xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"'
+      xmlNs: 'xmlns="http://www.example.org/schemas/sitemap/0.9"'
     })
 
     expect(result).toBe(expectedResult)
   })
   it('build sitemap index with lastmodISO', () => {
     var expectedResult = xmlDef +
-    '<sitemapindex xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">' +
+    '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' +
         '<sitemap>' +
             '<loc>https://test.com/s1.xml</loc>' +
             '<lastmod>2018-11-26</lastmod>' +
@@ -83,7 +83,7 @@ describe('sitemapIndex', () => {
           url: 'https://test.com/s3.xml'
         }
       ],
-      xmlNs: 'xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"',
+      xmlNs: 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"',
       lastmodISO: '2019-7-1'
     })
 
@@ -104,7 +104,7 @@ describe('sitemapIndex', () => {
       }
     };
     var expectedResult = xmlDef +
-    '<sitemapindex xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">' +
+    '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' +
         '<sitemap>' +
             '<loc>https://test.com/s1.xml</loc>' +
             `<lastmod>2019-05-14T11:01:58.135Z</lastmod>` +
@@ -117,7 +117,7 @@ describe('sitemapIndex', () => {
           url: 'https://test.com/s1.xml'
         }
       ],
-      xmlNs: 'xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"',
+      xmlNs: 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"',
       lastmodrealtime: true
     })
 
@@ -126,7 +126,7 @@ describe('sitemapIndex', () => {
   })
   it('build sitemap index with lastmod', () => {
     var expectedResult = xmlDef +
-    '<sitemapindex xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">' +
+    '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' +
         '<sitemap>' +
             '<loc>https://test.com/s1.xml</loc>' +
             '<lastmod>2018-11-26T00:00:00.000Z</lastmod>' +
@@ -139,7 +139,7 @@ describe('sitemapIndex', () => {
           url: 'https://test.com/s1.xml'
         }
       ],
-      xmlNs: 'xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"',
+      xmlNs: 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"',
       lastmod: '2018-11-26'
     })
 

--- a/tests/sitemap-index.test.ts
+++ b/tests/sitemap-index.test.ts
@@ -16,15 +16,15 @@ function removeFilesArray  (files) {
 const xmlDef = '<?xml version="1.0" encoding="UTF-8"?>'
 describe('sitemapIndex', () => {
   it('build sitemap index', () => {
-    var expectedResult = xmlDef + '\n' +
-    '<?xml-stylesheet type="text/xsl" href="https://test.com/style.xsl"?>\n' +
-    '<sitemapindex xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" xmlns:mobile="https://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="https://www.google.com/schemas/sitemap-image/1.1" xmlns:video="https://www.google.com/schemas/sitemap-video/1.1">\n' +
-    '<sitemap>\n' +
-    '<loc>https://test.com/s1.xml</loc>\n' +
-    '</sitemap>\n' +
-    '<sitemap>\n' +
-    '<loc>https://test.com/s2.xml</loc>\n' +
-    '</sitemap>\n' +
+    var expectedResult = xmlDef +
+    '<?xml-stylesheet type="text/xsl" href="https://test.com/style.xsl"?>' +
+    '<sitemapindex xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" xmlns:mobile="https://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="https://www.google.com/schemas/sitemap-image/1.1" xmlns:video="https://www.google.com/schemas/sitemap-video/1.1">' +
+    '<sitemap>' +
+    '<loc>https://test.com/s1.xml</loc>' +
+    '</sitemap>' +
+    '<sitemap>' +
+    '<loc>https://test.com/s2.xml</loc>' +
+    '</sitemap>' +
     '</sitemapindex>'
 
     var result = sm.buildSitemapIndex({
@@ -35,14 +35,14 @@ describe('sitemapIndex', () => {
     expect(result).toBe(expectedResult)
   })
   it('build sitemap index with custom xmlNS', () => {
-    var expectedResult = xmlDef + '\n' +
-    '<sitemapindex xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">\n' +
-        '<sitemap>\n' +
-            '<loc>https://test.com/s1.xml</loc>\n' +
-        '</sitemap>\n' +
-        '<sitemap>\n' +
-            '<loc>https://test.com/s2.xml</loc>\n' +
-        '</sitemap>\n' +
+    var expectedResult = xmlDef +
+    '<sitemapindex xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">' +
+        '<sitemap>' +
+            '<loc>https://test.com/s1.xml</loc>' +
+        '</sitemap>' +
+        '<sitemap>' +
+            '<loc>https://test.com/s2.xml</loc>' +
+        '</sitemap>' +
     '</sitemapindex>'
 
     var result = sm.buildSitemapIndex({
@@ -52,17 +52,21 @@ describe('sitemapIndex', () => {
 
     expect(result).toBe(expectedResult)
   })
-  it('build sitemap index with lastmod', () => {
-    var expectedResult = xmlDef + '\n' +
-    '<sitemapindex xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">\n' +
-        '<sitemap>\n' +
-            '<loc>https://test.com/s1.xml</loc>\n' +
-            '<lastmod>2018-11-26</lastmod>\n' +
-        '</sitemap>\n' +
-        '<sitemap>\n' +
-            '<loc>https://test.com/s2.xml</loc>\n' +
-            '<lastmod>2018-11-27</lastmod>\n' +
-        '</sitemap>\n' +
+  it('build sitemap index with lastmodISO', () => {
+    var expectedResult = xmlDef +
+    '<sitemapindex xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">' +
+        '<sitemap>' +
+            '<loc>https://test.com/s1.xml</loc>' +
+            '<lastmod>2018-11-26</lastmod>' +
+        '</sitemap>' +
+        '<sitemap>' +
+            '<loc>https://test.com/s2.xml</loc>' +
+            '<lastmod>2018-11-27</lastmod>' +
+        '</sitemap>' +
+        '<sitemap>' +
+            '<loc>https://test.com/s3.xml</loc>' +
+            '<lastmod>2019-7-1</lastmod>' +
+        '</sitemap>' +
     '</sitemapindex>'
 
     var result = sm.buildSitemapIndex({
@@ -73,10 +77,70 @@ describe('sitemapIndex', () => {
         },
         {
           url: 'https://test.com/s2.xml',
-          lastmod: '2018-11-27'
+          lastmodISO: '2018-11-27'
+        },
+        {
+          url: 'https://test.com/s3.xml'
         }
       ],
-      xmlNs: 'xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"'
+      xmlNs: 'xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"',
+      lastmodISO: '2019-7-1'
+    })
+
+    expect(result).toBe(expectedResult)
+  })
+  it('build sitemap index with lastmod realtime', () => {
+    const currentDate = new Date('2019-05-14T11:01:58.135Z');
+    const realDate = Date;
+    // @ts-ignore
+    global.Date = class extends Date {
+      constructor(date) {
+        if (date) {
+    // @ts-ignore
+          return super(date);
+        }
+
+        return currentDate;
+      }
+    };
+    var expectedResult = xmlDef +
+    '<sitemapindex xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">' +
+        '<sitemap>' +
+            '<loc>https://test.com/s1.xml</loc>' +
+            `<lastmod>2019-05-14T11:01:58.135Z</lastmod>` +
+        '</sitemap>' +
+    '</sitemapindex>'
+
+    var result = sm.buildSitemapIndex({
+      urls: [
+        {
+          url: 'https://test.com/s1.xml'
+        }
+      ],
+      xmlNs: 'xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"',
+      lastmodrealtime: true
+    })
+
+    expect(result).toBe(expectedResult)
+    global.Date = realDate;
+  })
+  it('build sitemap index with lastmod', () => {
+    var expectedResult = xmlDef +
+    '<sitemapindex xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">' +
+        '<sitemap>' +
+            '<loc>https://test.com/s1.xml</loc>' +
+            '<lastmod>2018-11-26T00:00:00.000Z</lastmod>' +
+        '</sitemap>' +
+    '</sitemapindex>'
+
+    var result = sm.buildSitemapIndex({
+      urls: [
+        {
+          url: 'https://test.com/s1.xml'
+        }
+      ],
+      xmlNs: 'xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"',
+      lastmod: '2018-11-26'
     })
 
     expect(result).toBe(expectedResult)

--- a/tests/sitemap-index.test.ts
+++ b/tests/sitemap-index.test.ts
@@ -18,7 +18,7 @@ describe('sitemapIndex', () => {
   it('build sitemap index', () => {
     var expectedResult = xmlDef +
     '<?xml-stylesheet type="text/xsl" href="https://test.com/style.xsl"?>' +
-    '<sitemapindex xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" xmlns:mobile="https://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="https://www.google.com/schemas/sitemap-image/1.1" xmlns:video="https://www.google.com/schemas/sitemap-video/1.1">' +
+    '<sitemapindex xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">' +
     '<sitemap>' +
     '<loc>https://test.com/s1.xml</loc>' +
     '</sitemap>' +

--- a/tests/sitemap.test.ts
+++ b/tests/sitemap.test.ts
@@ -9,14 +9,14 @@ import 'babel-polyfill'
 import sm, { EnumChangefreq, EnumYesNo, EnumAllowDeny } from '../index'
 import zlib from 'zlib'
 
-const urlset = '<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" ' +
-             'xmlns:news="https://www.google.com/schemas/sitemap-news/0.9" ' +
-             'xmlns:xhtml="https://www.w3.org/1999/xhtml" ' +
-             'xmlns:mobile="https://www.google.com/schemas/sitemap-mobile/1.0" ' +
-             'xmlns:image="https://www.google.com/schemas/sitemap-image/1.1" ' +
-             'xmlns:video="https://www.google.com/schemas/sitemap-video/1.1">'
+const urlset = '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" ' +
+             'xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" ' +
+             'xmlns:xhtml="http://www.w3.org/1999/xhtml" ' +
+             'xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" ' +
+             'xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" ' +
+             'xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">'
 
-const dynamicUrlSet = '<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">'
+const dynamicUrlSet = '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
 const xmlDef = '<?xml version="1.0" encoding="UTF-8"?>'
 const xmlPriority = '<priority>0.9</priority>'
 const xmlLoc = '<loc>http://ya.ru/</loc>'
@@ -96,7 +96,7 @@ describe('sitemap', () => {
   it('simple sitemap with dynamic xmlNs', () => {
     var url = 'http://ya.ru'
     var ssp = sm.createSitemap({
-      xmlNs: 'xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"'
+      xmlNs: 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"'
     })
     ssp.add(url)
 


### PR DESCRIPTION
switches part of sitemap index to use xmlbuilder
corrects an error where a globally specified lastmod would change from item to item
ups test coverage