### PR TITLE
3.2.2 lastmod, xmlns fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.2.2
+  - revert https everywhere added in 3.2.0. xmlns is not url.
+  - adds alias for lastmod in the form of lastmodiso
+  - fixes bug in lastmod option for buildSitemapIndex where option would be overwritten if a lastmod option was provided with a single url
+  - fixes #201, fixes #203
 # 3.2.1
   - no really fixes ts errors for real this time
   - fixes #193 in PR #198

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sitemap",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sitemap",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Sitemap-generating framework",
   "keywords": [
     "sitemap",


### PR DESCRIPTION
# 3.2.2
  - revert https everywhere added in 3.2.0. xmlns is not url.
  - adds alias for lastmod in the form of lastmodiso
  - fixes bug in lastmod option for buildSitemapIndex where option would be overwritten if a lastmod option was provided with a single url
  - fixes #201, fixes #203