### PR TITLE
release 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # master
+
+# 4.1.0
 Add a pretty print option to `toString(false)`
 pass true pretty print
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sitemap",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sitemap",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "description": "Sitemap-generating framework",
   "keywords": [
     "sitemap",


### PR DESCRIPTION
Add a pretty print option to toString(false) pass true pretty print #230 

[Add an xmlparser](https://github.com/ekalinin/sitemap.js/pull/232) that will output a config that would generate that same file 

cli: use --parser to output the complete config --line-separated to print out line separated config compatible with the --json input option for cli

 lib: import parseSitemap and pass it a stream