### PR TITLE
package updates, retry on test failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
 install:
   - npm install
 script:
-  - npm test
+  - travis_retry npm test
 addons:
   apt:
     packages:

--- a/package-lock.json
+++ b/package-lock.json
@@ -4380,38 +4380,6 @@
         "handlebars": "^4.1.2"
       }
     },
-    "jasmine": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.4.0.tgz",
-      "integrity": "sha512-sR9b4n+fnBFDEd7VS2el2DeHgKcPiMVn44rtKFumq9q7P/t8WrxsVIZPob4UDdgcDNCwyDqwxCt4k9TDRmjPoQ==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.1.3",
-        "jasmine-core": "~3.4.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
-      }
-    },
-    "jasmine-core": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.4.0.tgz",
-      "integrity": "sha512-HU/YxV4i6GcmiH4duATwAbJQMlE0MsDIR5XmSVxURxKHn3aGAdbY1/ZJFmVRbKtnLwIxxMJD7gYaPsypcbYimg==",
-      "dev": true
-    },
     "jest": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1433,9 +1433,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.7.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.2.tgz",
-      "integrity": "sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg=="
+      "version": "12.7.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.3.tgz",
+      "integrity": "sha512-3SiLAIBkDWDg6vFo0+5YJyHPWU9uwu40Qe+v+0MH8wRKYBimHvvAOyk3EzMrD/TrIlLYfXrqDqrg913PynrMJQ=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -2642,9 +2642,9 @@
       }
     },
     "eslint": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.2.2.tgz",
-      "integrity": "sha512-mf0elOkxHbdyGX1IJEUsNBzCDdyoUgljF3rRlgfyYh0pwGnreLc0jjD6ZuleOibjmnUWZLY2eXwSooeOgGJ2jw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.3.0.tgz",
+      "integrity": "sha512-ZvZTKaqDue+N8Y9g0kp6UPZtS4FSY3qARxBs7p4f0H0iof381XHduqVerFWtK8DPtKmemqbqCFENWSQgPR/Gow==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -2711,9 +2711,9 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "22.15.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.15.2.tgz",
-      "integrity": "sha512-p4NME9TgXIt+KgpxcXyNBvO30ZKxwFAO1dJZBc2OGfDnXVEtPwEyNs95GSr6RIE3xLHdjd8ngDdE2icRRXrbxg==",
+      "version": "22.16.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.16.0.tgz",
+      "integrity": "sha512-eBtSCDhO1k7g3sULX/fuRK+upFQ7s548rrBtxDyM1fSoY7dTWp/wICjrJcDZKVsW7tsFfH22SG+ZaxG5BZodIg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/experimental-utils": "^1.13.0"
@@ -6794,9 +6794,9 @@
       }
     },
     "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
+      "integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     }
   },
   "dependencies": {
-    "@types/node": "^12.7.2",
+    "@types/node": "^12.7.3",
     "@types/sax": "^1.2.0",
     "arg": "^4.1.1",
     "sax": "^1.2.4",
@@ -119,14 +119,14 @@
     "@typescript-eslint/parser": "^2.0.0",
     "babel-eslint": "^10.0.3",
     "babel-polyfill": "^6.26.0",
-    "eslint": "^6.2.2",
-    "eslint-plugin-jest": "^22.15.2",
+    "eslint": "^6.3.0",
+    "eslint-plugin-jest": "^22.16.0",
     "husky": "^3.0.4",
     "jest": "^24.9.0",
     "sort-package-json": "^1.22.1",
     "source-map": "~0.7.3",
     "stats-lite": "^2.2.0",
-    "typescript": "^3.5.3"
+    "typescript": "^3.6.2"
   },
   "engines": {
     "node": ">=8.9.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build": "tsc",
     "prepublishOnly": "sort-package-json && npm run test",
     "test": "eslint lib/* ./cli.ts && tsc && jest && npm run test:xmllint",
-    "test-fast": "jest ./tests/sitemap-item.test.ts ./tests/sitemap-index.test.ts ./tests/sitemap.test.ts ./tests/sitemap-shape.test.ts",
+    "test-fast": "eslint lib/* ./cli.ts && tsc && jest ./tests/sitemap*",
     "test-perf": "node ./tests/perf.js > /dev/null",
     "test:schema": "node tests/alltags.js | xmllint --schema schema/all.xsd --noout -",
     "test:typecheck": "tsc",
@@ -36,7 +36,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "sort-package-json",
-      "pre-push": "npm test"
+      "pre-push": "npm run test-fast"
     }
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "eslint": "^6.2.2",
     "eslint-plugin-jest": "^22.15.2",
     "husky": "^3.0.4",
-    "jasmine": "^3.4.0",
     "jest": "^24.9.0",
     "sort-package-json": "^1.22.1",
     "source-map": "~0.7.3",

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -8,7 +8,7 @@ const pkg = require('../package.json')
 const nomralizedSample = require('./mocks/sampleconfig.normalized.json')
 let hasXMLLint = true
 try {
-  const lintCheck = execFileSync('which', ['xmlLint'])
+  execFileSync('which', ['xmllint'])
 } catch {
   hasXMLLint = false
 }

--- a/tests/xmllint.test.ts
+++ b/tests/xmllint.test.ts
@@ -4,7 +4,7 @@ import { xmlLint } from '../index'
 const execFileSync = require('child_process').execFileSync
 let hasXMLLint = true
 try {
-  execFileSync("which", ["xmlLint"]);
+  execFileSync("which", ["xmllint"]);
 } catch {
   hasXMLLint = false
 }


### PR DESCRIPTION
This is mostly a pr to make xmllint failures a little less catastrophic as it has network dependencies that can sometimes fail. Other updates include some minor package updates, removal the unused jasmine lib, and changing the push hook to run a lighter set of test so as to not discourage contribution.