### PR TITLE
release 5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 5.0.1
+
+Fix for issue #254. ```
+warning: failed to load external entity "./schema/all.xsd"
+Schemas parser error : Failed to locate the main schema resource at './schema/all.xsd'.
+WXS schema ./schema/all.xsd failed to compile
+```
+
 # 5.0.0
 ## Streams
 This release is heavily focused on converting the core methods of this library to use streams. Why? Overall its made the API ~20% faster and uses only 10% or less of the memory. Some tradeoffs had to be made as in their nature streams are operate on individual segments of data as opposed to the whole. For instance, the streaming interface does not support removal of sitemap items as it does not hold on to a sitemap item after its converted to XML. It should however be possible to create your own transform that filters out entries should you desire it. The existing synchronous interfaces will remain for this release at least. Do not be surprised if they go away in a future breaking release.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sitemap",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sitemap",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Sitemap-generating lib/cli",
   "keywords": [
     "sitemap",


### PR DESCRIPTION
# 5.0.1

Fix for issue #254. ```
warning: failed to load external entity "./schema/all.xsd"
Schemas parser error : Failed to locate the main schema resource at './schema/all.xsd'.
WXS schema ./schema/all.xsd failed to compile```