### PR TITLE
Add errorHandler option

### DIFF
--- a/api.md
+++ b/api.md
@@ -1,21 +1,22 @@
 # API
 
-- [SitemapStream](#sitemapstream)
-- [XMLToSitemapItemStream](#XMLToSitemapItemStream)
-- [sitemapAndIndexStream](#sitemapandindexstream)
-- [createSitemapsAndIndex](#createsitemapsandindex)
-- [SitemapIndexStream](#SitemapIndexStream)
-- [xmlLint](#xmllint)
-- [parseSitemap](#parsesitemap)
-- [lineSeparatedURLsToSitemapOptions](#lineseparatedurlstositemapoptions)
-- [streamToPromise](#streamtopromise)
-- [ObjectStreamToJSON](#objectstreamtojson)
-- [SitemapItemStream](#SitemapItemStream)
-- [Sitemap Item Options](#sitemap-item-options)
-- [SitemapImage](#sitemapimage)
-- [VideoItem](#videoitem)
-- [LinkItem](#linkitem)
-- [NewsItem](#newsitem)
+- [API](#api)
+  - [SitemapStream](#sitemapstream)
+  - [XMLToSitemapItemStream](#xmltositemapitemstream)
+  - [sitemapAndIndexStream](#sitemapandindexstream)
+  - [createSitemapsAndIndex](#createsitemapsandindex)
+  - [SitemapIndexStream](#sitemapindexstream)
+  - [xmlLint](#xmllint)
+  - [parseSitemap](#parsesitemap)
+  - [lineSeparatedURLsToSitemapOptions](#lineseparatedurlstositemapoptions)
+  - [streamToPromise](#streamtopromise)
+  - [ObjectStreamToJSON](#objectstreamtojson)
+  - [SitemapItemStream](#sitemapitemstream)
+  - [Sitemap Item Options](#sitemap-item-options)
+  - [SitemapImage](#sitemapimage)
+  - [VideoItem](#videoitem)
+  - [ILinkItem](#ilinkitem)
+  - [NewsItem](#newsitem)
 
 ## SitemapStream
 
@@ -32,7 +33,8 @@ const sms = new SitemapStream({
     image: true,
     video: true,
     // custom: ['xmlns:custom="https://example.com"']
-  }
+  },
+  errorHandler: undefined // defaults to a standard errorLogger that logs to console or throws if the errorLevel is set to throw
 })
 const readable = // a readable stream of objects
 readable.pipe(sms).pipe(process.stdout)

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -368,6 +368,8 @@ export enum ErrorLevel {
   THROW = 'throw',
 }
 
+export type ErrorHandler = (error: Error, level: ErrorLevel) => void;
+
 export enum TagNames {
   url = 'url',
   loc = 'loc',

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -21,6 +21,7 @@ import {
   isPriceType,
   isResolution,
   NewsItem,
+  ErrorHandler,
 } from './types';
 import {
   ChangeFreqInvalidError,
@@ -83,7 +84,7 @@ function handleError(error: Error, level: ErrorLevel): void {
 export function validateSMIOptions(
   conf: SitemapItem,
   level = ErrorLevel.WARN,
-  errorHandler = handleError
+  errorHandler: ErrorHandler = handleError
 ): SitemapItem {
   if (!conf) {
     throw new NoConfigError();

--- a/tests/sitemap-stream.test.ts
+++ b/tests/sitemap-stream.test.ts
@@ -69,4 +69,26 @@ describe('sitemap stream', () => {
         closetag
     );
   });
+
+  it('invokes custom errorHandler', async () => {
+    const source = [
+      { url: '/', changefreq: 'daily' },
+      { url: '/path', changefreq: 'invalid' },
+    ];
+    const errorHandlerMock = jest.fn();
+    const sms = new SitemapStream({
+      hostname: 'https://example.com/',
+      errorHandler: errorHandlerMock,
+    });
+    sms.write(source[0]);
+    sms.write(source[1]);
+    sms.end();
+    expect(errorHandlerMock.mock.calls.length).toBe(1);
+    expect((await streamToPromise(sms)).toString()).toBe(
+      preamble +
+        `<url><loc>https://example.com/</loc><changefreq>daily</changefreq></url>` +
+        `<url><loc>https://example.com/path</loc><changefreq>invalid</changefreq></url>` +
+        closetag
+    );
+  });
 });


### PR DESCRIPTION
Related to #348 .

This PR exposes the errorHandler option so that its behavior can be customized (for examples, some errors may be ignored, some others may be considered critical, and so on).