### PR TITLE
Add Sitemap Index XML parser

### DIFF
--- a/lib/sitemap-index-parser.ts
+++ b/lib/sitemap-index-parser.ts
@@ -1,0 +1,211 @@
+import sax, { SAXStream } from 'sax';
+import {
+  Readable,
+  Transform,
+  TransformOptions,
+  TransformCallback,
+} from 'stream';
+import { IndexItem, ErrorLevel, IndexTagNames } from './types';
+
+function isValidTagName(tagName: string): tagName is IndexTagNames {
+  // This only works because the enum name and value are the same
+  return tagName in IndexTagNames;
+}
+
+function tagTemplate(): IndexItem {
+  return {
+    url: '',
+  };
+}
+
+type Logger = (
+  level: 'warn' | 'error' | 'info' | 'log',
+  ...message: Parameters<Console['log']>[0]
+) => void;
+export interface XMLToSitemapIndexItemStreamOptions extends TransformOptions {
+  level?: ErrorLevel;
+  logger?: Logger | false;
+}
+const defaultLogger: Logger = (level, ...message) => console[level](...message);
+const defaultStreamOpts: XMLToSitemapIndexItemStreamOptions = {
+  logger: defaultLogger,
+};
+
+// TODO does this need to end with `options`
+/**
+ * Takes a stream of xml and transforms it into a stream of IndexItems
+ * Use this to parse existing sitemap indices into config options compatible with this library
+ */
+export class XMLToSitemapIndexStream extends Transform {
+  level: ErrorLevel;
+  logger: Logger;
+  saxStream: SAXStream;
+  constructor(opts = defaultStreamOpts) {
+    opts.objectMode = true;
+    super(opts);
+    this.saxStream = sax.createStream(true, {
+      xmlns: true,
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      strictEntities: true,
+      trim: true,
+    });
+    this.level = opts.level || ErrorLevel.WARN;
+    if (this.level !== ErrorLevel.SILENT && opts.logger !== false) {
+      this.logger = opts.logger ?? defaultLogger;
+    } else {
+      this.logger = () => undefined;
+    }
+    let currentItem: IndexItem = tagTemplate();
+    let currentTag: string;
+    this.saxStream.on('opentagstart', (tag): void => {
+      currentTag = tag.name;
+    });
+
+    this.saxStream.on('opentag', (tag): void => {
+      if (!isValidTagName(tag.name)) {
+        this.logger('warn', 'unhandled tag', tag.name);
+      }
+    });
+
+    this.saxStream.on('text', (text): void => {
+      switch (currentTag) {
+        case IndexTagNames.loc:
+          currentItem.url = text;
+          break;
+        case IndexTagNames.lastmod:
+          currentItem.lastmod = text;
+          break;
+        default:
+          this.logger(
+            'log',
+            'unhandled text for tag:',
+            currentTag,
+            `'${text}'`
+          );
+          break;
+      }
+    });
+
+    this.saxStream.on('cdata', (_text): void => {
+      switch (currentTag) {
+        default:
+          this.logger('log', 'unhandled cdata for tag:', currentTag);
+          break;
+      }
+    });
+
+    this.saxStream.on('attribute', (attr): void => {
+      switch (currentTag) {
+        case IndexTagNames.sitemapindex:
+          break;
+        default:
+          this.logger('log', 'unhandled attr', currentTag, attr.name);
+      }
+    });
+
+    this.saxStream.on('closetag', (tag): void => {
+      switch (tag) {
+        case IndexTagNames.sitemap:
+          this.push(currentItem);
+          currentItem = tagTemplate();
+          break;
+
+        default:
+          break;
+      }
+    });
+  }
+
+  _transform(
+    data: string,
+    encoding: string,
+    callback: TransformCallback
+  ): void {
+    // correcting the type here can be done without making it a breaking change
+    // TODO fix this
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    this.saxStream.write(data, encoding);
+    callback();
+  }
+}
+
+/**
+  Read xml and resolve with the configuration that would produce it or reject with
+  an error
+  ```
+  const { createReadStream } = require('fs')
+  const { parseSitemapIndex, createSitemap } = require('sitemap')
+  parseSitemapIndex(createReadStream('./example-index.xml')).then(
+    // produces the same xml
+    // you can, of course, more practically modify it or store it
+    (xmlConfig) => console.log(createSitemap(xmlConfig).toString()),
+    (err) => console.log(err)
+  )
+  ```
+  @param {Readable} xml what to parse
+  @return {Promise<IndexItem[]>} resolves with list of index items that can be fed into a SitemapIndexStream. Rejects with an Error object.
+ */
+export async function parseSitemapIndex(xml: Readable): Promise<IndexItem[]> {
+  const urls: IndexItem[] = [];
+  return new Promise((resolve, reject): void => {
+    xml
+      .pipe(new XMLToSitemapIndexStream())
+      .on('data', (smi: IndexItem) => urls.push(smi))
+      .on('end', (): void => {
+        resolve(urls);
+      })
+      .on('error', (error: Error): void => {
+        reject(error);
+      });
+  });
+}
+
+export interface IndexObjectStreamToJSONOptions extends TransformOptions {
+  lineSeparated: boolean;
+}
+
+const defaultObjectStreamOpts: IndexObjectStreamToJSONOptions = {
+  lineSeparated: false,
+};
+/**
+ * A Transform that converts a stream of objects into a JSON Array or a line
+ * separated stringified JSON
+ * @param [lineSeparated=false] whether to separate entries by a new line or comma
+ */
+export class IndexObjectStreamToJSON extends Transform {
+  lineSeparated: boolean;
+  firstWritten: boolean;
+
+  constructor(opts = defaultObjectStreamOpts) {
+    opts.writableObjectMode = true;
+    super(opts);
+    this.lineSeparated = opts.lineSeparated;
+    this.firstWritten = false;
+  }
+
+  _transform(chunk: IndexItem, encoding: string, cb: TransformCallback): void {
+    if (!this.firstWritten) {
+      this.firstWritten = true;
+      if (!this.lineSeparated) {
+        this.push('[');
+      }
+    } else if (this.lineSeparated) {
+      this.push('\n');
+    } else {
+      this.push(',');
+    }
+    if (chunk) {
+      this.push(JSON.stringify(chunk));
+    }
+    cb();
+  }
+
+  _flush(cb: TransformCallback): void {
+    if (!this.lineSeparated) {
+      this.push(']');
+    }
+    cb();
+  }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -425,3 +425,10 @@ export enum TagNames {
   'xhtml:link' = 'xhtml:link',
   'expires' = 'expires',
 }
+
+export enum IndexTagNames {
+  sitemap = 'sitemap',
+  sitemapindex = 'sitemapindex',
+  loc = 'loc',
+  lastmod = 'lastmod',
+}

--- a/tests/mocks/alltags-index.cdata.xml
+++ b/tests/mocks/alltags-index.cdata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd"
+         xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <foo>
+  <![CDATA[http://www.example.com/sitemap1.xml.gz&><'"]]>
+  </foo>
+  <sitemap>
+    <loc>https://www.example.com/sitemap1.xml.gz</loc>
+    <lastmod>2004-10-01T18:23:17+00:00</lastmod>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.example.com/sitemap2.xml.gz</loc>
+    <lastmod>2005-01-01</lastmod>
+  </sitemap>
+</sitemapindex>

--- a/tests/mocks/alltags-index.xml
+++ b/tests/mocks/alltags-index.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd"
+         xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://www.example.com/sitemap1.xml.gz</loc>
+    <lastmod>2004-10-01T18:23:17+00:00</lastmod>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.example.com/sitemap2.xml.gz</loc>
+    <lastmod>2005-01-01</lastmod>
+  </sitemap>
+</sitemapindex>

--- a/tests/mocks/bad-tag-index.xml
+++ b/tests/mocks/bad-tag-index.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd"
+         xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <foo>
+    This is not a good tag
+  </foo>
+  <sitemap>
+    <loc>https://www.example.com/sitemap1.xml.gz</loc>
+    <lastmod>2004-10-01T18:23:17+00:00</lastmod>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.example.com/sitemap2.xml.gz</loc>
+    <lastmod>2005-01-01</lastmod>
+  </sitemap>
+</sitemapindex>

--- a/tests/mocks/sampleconfig-index.normalized.json
+++ b/tests/mocks/sampleconfig-index.normalized.json
@@ -1,0 +1,12 @@
+{
+  "sitemaps": [
+    {
+      "lastmod": "2004-10-01T18:23:17+00:00",
+      "url": "https://www.example.com/sitemap1.xml.gz"
+    },
+    {
+      "lastmod": "2005-01-01",
+      "url": "https://www.example.com/sitemap2.xml.gz"
+    }
+  ]
+}

--- a/tests/sitemap-index-parser.test.ts
+++ b/tests/sitemap-index-parser.test.ts
@@ -1,0 +1,158 @@
+import { createReadStream } from 'fs';
+import { resolve } from 'path';
+import { promisify } from 'util';
+import { pipeline as pipe, Writable, Readable } from 'stream';
+import {
+  parseSitemapIndex,
+  XMLToSitemapIndexStream,
+  IndexObjectStreamToJSON,
+} from '../lib/sitemap-index-parser';
+import { ErrorLevel, IndexItem } from '../lib/types';
+const pipeline = promisify(pipe);
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const normalizedSample = require('./mocks/sampleconfig-index.normalized.json');
+describe('parseSitemapIndex', () => {
+  it('parses xml into index-items', async () => {
+    const urls = await parseSitemapIndex(
+      createReadStream(resolve(__dirname, './mocks/alltags-index.xml'), {
+        encoding: 'utf8',
+      })
+    );
+    expect(urls).toEqual(normalizedSample.sitemaps);
+  });
+});
+
+describe('XMLToSitemapIndexItemStream', () => {
+  it('stream parses XML', async () => {
+    const sitemap: IndexItem[] = [];
+    await pipeline(
+      createReadStream(resolve(__dirname, './mocks/alltags-index.xml'), {
+        encoding: 'utf8',
+      }),
+      new XMLToSitemapIndexStream(),
+      new Writable({
+        objectMode: true,
+        write(chunk, a, cb): void {
+          sitemap.push(chunk);
+          cb();
+        },
+      })
+    );
+    expect(sitemap).toEqual(normalizedSample.sitemaps);
+  });
+
+  it('stream parses bad XML', async () => {
+    const sitemap: IndexItem[] = [];
+    const logger = jest.fn();
+    await pipeline(
+      createReadStream(resolve(__dirname, './mocks/bad-tag-index.xml'), {
+        encoding: 'utf8',
+      }),
+      new XMLToSitemapIndexStream({ logger }),
+      new Writable({
+        objectMode: true,
+        write(chunk, a, cb): void {
+          sitemap.push(chunk);
+          cb();
+        },
+      })
+    );
+    expect(sitemap).toEqual(normalizedSample.sitemaps);
+    expect(logger.mock.calls.length).toBe(2);
+    expect(logger.mock.calls[0][1]).toBe('unhandled tag');
+    expect(logger.mock.calls[0][2]).toBe('foo');
+  });
+
+  it('stream parses bad XML - silently', async () => {
+    const sitemap: IndexItem[] = [];
+    const logger = jest.fn();
+    await pipeline(
+      createReadStream(resolve(__dirname, './mocks/bad-tag-index.xml'), {
+        encoding: 'utf8',
+      }),
+      new XMLToSitemapIndexStream({ logger, level: ErrorLevel.SILENT }),
+      new Writable({
+        objectMode: true,
+        write(chunk, a, cb): void {
+          sitemap.push(chunk);
+          cb();
+        },
+      })
+    );
+    expect(sitemap).toEqual(normalizedSample.sitemaps);
+    expect(logger.mock.calls.length).toBe(0);
+  });
+
+  it('stream parses XML with cdata', async () => {
+    const sitemap: IndexItem[] = [];
+    const logger = jest.fn();
+    await pipeline(
+      createReadStream(resolve(__dirname, './mocks/alltags-index.cdata.xml'), {
+        encoding: 'utf8',
+      }),
+      new XMLToSitemapIndexStream({ logger }),
+      new Writable({
+        objectMode: true,
+        write(chunk, a, cb): void {
+          sitemap.push(chunk);
+          cb();
+        },
+      })
+    );
+    expect(sitemap).toEqual(normalizedSample.sitemaps);
+    expect(logger.mock.calls.length).toBe(2);
+    expect(logger.mock.calls[0][1]).toBe('unhandled tag');
+    expect(logger.mock.calls[0][2]).toBe('foo');
+    expect(logger.mock.calls[1][1]).toBe('unhandled cdata for tag:');
+    expect(logger.mock.calls[1][2]).toBe('foo');
+  });
+
+  it('stream parses XML with cdata - silently', async () => {
+    const sitemap: IndexItem[] = [];
+    const logger = jest.fn();
+    await pipeline(
+      createReadStream(resolve(__dirname, './mocks/alltags-index.cdata.xml'), {
+        encoding: 'utf8',
+      }),
+      new XMLToSitemapIndexStream({ logger, level: ErrorLevel.SILENT }),
+      new Writable({
+        objectMode: true,
+        write(chunk, a, cb): void {
+          sitemap.push(chunk);
+          cb();
+        },
+      })
+    );
+    expect(sitemap).toEqual(normalizedSample.sitemaps);
+    expect(logger.mock.calls.length).toBe(0);
+  });
+});
+
+describe('ObjectStreamToJSON', () => {
+  it('turns a stream of sitemapItems to string', async () => {
+    let sitemap = '';
+    const items = [{ foo: 'bar' }, { fizz: 'buzz' }];
+    const itemsSource = [...items];
+    const readable = new Readable({
+      objectMode: true,
+      read(size): void {
+        this.push(itemsSource.shift());
+        if (!itemsSource.length) {
+          this.push(null);
+        }
+      },
+    });
+    await pipeline(
+      readable,
+      new IndexObjectStreamToJSON(),
+      new Writable({
+        objectMode: true,
+        write(chunk, a, cb): void {
+          sitemap += chunk;
+          cb();
+        },
+      })
+    );
+    expect(sitemap).toBe(JSON.stringify(items));
+  });
+});

--- a/tests/sitemap-parser.test.ts
+++ b/tests/sitemap-parser.test.ts
@@ -8,7 +8,7 @@ import {
   ObjectStreamToJSON,
 } from '../lib/sitemap-parser';
 import { SitemapStreamOptions } from '../dist';
-import { ErrorLevel } from '../lib/types';
+import { ErrorLevel, SitemapItem } from '../lib/types';
 const pipeline = promisify(pipe);
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const normalizedSample = require('./mocks/sampleconfig.normalized.json');
@@ -25,7 +25,7 @@ describe('parseSitemap', () => {
 
 describe('XMLToSitemapItemStream', () => {
   it('stream parses XML', async () => {
-    const sitemap: SitemapStreamOptions[] = [];
+    const sitemap: SitemapItem[] = [];
     await pipeline(
       createReadStream(resolve(__dirname, './mocks/alltags.xml'), {
         encoding: 'utf8',
@@ -62,7 +62,11 @@ describe('XMLToSitemapItemStream', () => {
     expect(logger.mock.calls.length).toBe(2);
     expect(logger.mock.calls[0][1]).toBe('unhandled tag');
     expect(logger.mock.calls[0][2]).toBe('foo');
+  });
 
+  it('stream parses bad XML - silently', async () => {
+    const sitemap: SitemapStreamOptions[] = [];
+    const logger = jest.fn();
     await pipeline(
       createReadStream(resolve(__dirname, './mocks/bad-tag-sitemap.xml'), {
         encoding: 'utf8',
@@ -76,7 +80,8 @@ describe('XMLToSitemapItemStream', () => {
         },
       })
     );
-    expect(logger.mock.calls.length).toBe(2);
+    expect(sitemap).toEqual(normalizedSample.urls);
+    expect(logger.mock.calls.length).toBe(0);
   });
 
   it('stream parses XML with cdata', async () => {


### PR DESCRIPTION
- This makes the module able to parse both XML sitemaps and XML sitemap indices
- I personally spent about a day thinking that I had a bug in my code before realizing that there was no XML parser for sitemap indices in the library :)