### PR TITLE
Fix parseSitemap and parseSitemapIndex uncatchable errors

### DIFF
--- a/lib/sitemap-index-parser.ts
+++ b/lib/sitemap-index-parser.ts
@@ -122,12 +122,16 @@ export class XMLToSitemapIndexStream extends Transform {
     encoding: string,
     callback: TransformCallback
   ): void {
-    // correcting the type here can be done without making it a breaking change
-    // TODO fix this
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    this.saxStream.write(data, encoding);
-    callback();
+    try {
+      // correcting the type here can be done without making it a breaking change
+      // TODO fix this
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      this.saxStream.write(data, encoding);
+      callback();
+    } catch (error) {
+      callback(error);
+    }
   }
 }
 

--- a/lib/sitemap-parser.ts
+++ b/lib/sitemap-parser.ts
@@ -457,12 +457,16 @@ export class XMLToSitemapItemStream extends Transform {
     encoding: string,
     callback: TransformCallback
   ): void {
-    // correcting the type here can be done without making it a breaking change
-    // TODO fix this
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    this.saxStream.write(data, encoding);
-    callback();
+    try {
+      // correcting the type here can be done without making it a breaking change
+      // TODO fix this
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      this.saxStream.write(data, encoding);
+      callback();
+    } catch (error) {
+      callback(error);
+    }
   }
 }
 

--- a/tests/mocks/index-unescaped-lt.xml
+++ b/tests/mocks/index-unescaped-lt.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd"
+         xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://www.example.com/sitemap1.xml.gz</loc>
+    <lastmod>2004-10-01T18:23:17+00:00</lastmod>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.example.com/sitemap2.xml.gz</loc>
+    <lastmod>2005-01-01<</lastmod>
+  </sitemap>
+</sitemapindex>

--- a/tests/mocks/unescaped-lt.xml
+++ b/tests/mocks/unescaped-lt.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+  <url>
+    <loc>http://example.com&amp;&gt;&lt;'"/</loc>
+    <lastmod>2011-06-27T00:00:00.000Z</lastmod>
+    <changefreq>always<</changefreq>
+    <priority>0.9</priority>
+    <image:image>
+      <image:loc>http://urltest.com&amp;&gt;&lt;'"/</image:loc>
+    </image:image>
+  </url>
+</urlset>

--- a/tests/sitemap-index-parser.test.ts
+++ b/tests/sitemap-index-parser.test.ts
@@ -20,6 +20,16 @@ describe('parseSitemapIndex', () => {
     );
     expect(urls).toEqual(normalizedSample.sitemaps);
   });
+
+  it('rejects malformed file', async () => {
+    await expect(async () =>
+      parseSitemapIndex(
+        createReadStream(resolve(__dirname, './mocks/index-unescaped-lt.xml'), {
+          encoding: 'utf8',
+        })
+      )
+    ).rejects.toThrow();
+  });
 });
 
 describe('XMLToSitemapIndexItemStream', () => {

--- a/tests/sitemap-parser.test.ts
+++ b/tests/sitemap-parser.test.ts
@@ -21,6 +21,16 @@ describe('parseSitemap', () => {
     );
     expect(urls).toEqual(normalizedSample.urls);
   });
+
+  it('rejects malformed file', async () => {
+    await expect(async () =>
+      parseSitemap(
+        createReadStream(resolve(__dirname, './mocks/unescaped-lt.xml'), {
+          encoding: 'utf8',
+        })
+      )
+    ).rejects.toThrow();
+  });
 });
 
 describe('XMLToSitemapItemStream', () => {


### PR DESCRIPTION
- `parseSitemap` and `parseSitemapIndex` both have an issue where errors in the `_transform` function are not catchable by the caller and instead result in an `Unhandled error`.
- The file that causes this problem was written with `sitemap.js` but it's not yet clear if the malformed file indicates that there is another bug to be fixed or if that is more indicative of a problem in my consumption of the library.  More to follow on that if I find another issue.
- Added a test that fails before the fix and that passes after the fix

# Before Fix - Output

The output below would result if `parseSitemapIndex` or `parseSitemap` were called on a malformed XML file that has an unescaped `<` in the text of a tag.

```
 FAIL  tests/sitemap-index-parser.test.ts
  ● parseSitemapIndex › rejects malformed file

    Unhandled error. (Error: Unencoded <
    Line: 10
    Column: 25
    Char: <

      127 |     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
      128 |     // @ts-ignore
    > 129 |     this.saxStream.write(data, encoding);
          |                    ^
      130 |     callback();
      131 |   }
      132 | }

      at error (node_modules/sax/lib/sax.js:651:10)
      at strictFail (node_modules/sax/lib/sax.js:677:7)
      at SAXParser.write (node_modules/sax/lib/sax.js:1080:13)
      at SAXStream.write (node_modules/sax/lib/sax.js:239:18)
      at XMLToSitemapIndexStream._transform (lib/sitemap-index-parser.ts:129:20)
      Line: 10
      Column: 25
      Char: <
      at error (node_modules/sax/lib/sax.js:651:10)
      at strictFail (node_modules/sax/lib/sax.js:677:7)
      at SAXParser.write (node_modules/sax/lib/sax.js:1080:13)
      at SAXStream.write (node_modules/sax/lib/sax.js:239:18)
      at XMLToSitemapIndexStream._transform (lib/sitemap-index-parser.ts:129:20)
      at SAXParser.SAXStream._parser.onerror (node_modules/sax/lib/sax.js:194:10)
      at emit (node_modules/sax/lib/sax.js:624:35)
      at error (node_modules/sax/lib/sax.js:653:5)
      at strictFail (node_modules/sax/lib/sax.js:677:7)
      at SAXParser.write (node_modules/sax/lib/sax.js:1080:13)
      at SAXStream.write (node_modules/sax/lib/sax.js:239:18)
      at XMLToSitemapIndexStream._transform (lib/sitemap-index-parser.ts:129:20)
```