### PR TITLE
Update types.ts

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -17,7 +17,7 @@ export enum EnumChangefreq {
 }
 
 const allowDeny = /^(?:allow|deny)$/;
-export const validators: { [index: string]: RegExp } = {
+export const validators: { [index: string]: RegExp; } = {
   'price:currency': /^[A-Z]{3}$/,
   'price:type': /^(?:rent|purchase|RENT|PURCHASE)$/,
   'price:resolution': /^(?:HD|hd|sd|SD)$/,
@@ -325,7 +325,7 @@ export interface IndexItem {
 
 interface SitemapItemBase {
   lastmod?: string;
-  changefreq?: EnumChangefreq;
+  changefreq?: EnumChangefreq | 'daily' | 'monthly' | 'always' | 'hourly' | 'weekly' | 'yearly' | 'never';
   fullPrecisionPriority?: boolean;
   priority?: number;
   news?: NewsItem;


### PR DESCRIPTION
When using this package with typescript. Typescript compilers throws error that you are not using "EnumChangefreq". but as I saw the compiled output of the program doesn't really uses it. So it is better to give users the freedom and correct type both.