### PR TITLE
Fix exports for sitemap index parsing (fixes #384)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -37,5 +37,12 @@ export {
   ObjectStreamToJSON,
   ObjectStreamToJSONOptions,
 } from './lib/sitemap-parser';
+export {
+  parseSitemapIndex,
+  XMLToSitemapIndexStream,
+  XMLToSitemapIndexItemStreamOptions,
+  IndexObjectStreamToJSON,
+  IndexObjectStreamToJSONOptions,
+} from './lib/sitemap-index-parser';
 
 export { simpleSitemapAndIndex } from './lib/sitemap-simple';


### PR DESCRIPTION
**Changes:**
- export all relevant members of `./lib/sitemap-index-parser` in main `index.ts`

Fix for #384 