### PR TITLE
Added nameGenerator for sitemap simple index

### DIFF
--- a/lib/sitemap-simple.ts
+++ b/lib/sitemap-simple.ts
@@ -13,6 +13,11 @@ import { URL } from 'url';
 import { WriteStream } from 'fs';
 
 const pipeline = promisify(pline);
+
+function defaultNameGenerator(index: number) {
+  return `./sitemap-${index}.xml`;
+}
+
 /**
  *
  * @param {object} options -
@@ -36,6 +41,7 @@ export const simpleSitemapAndIndex = async ({
   limit = 50000,
   gzip = true,
   publicBasePath = './',
+  nameGenerator = defaultNameGenerator,
 }: {
   hostname: string;
   sitemapHostname?: string;
@@ -44,6 +50,7 @@ export const simpleSitemapAndIndex = async ({
   publicBasePath?: string;
   limit?: number;
   gzip?: boolean;
+  nameGenerator?: (index: number) => string;
 }): Promise<void> => {
   await promises.mkdir(destinationDir, { recursive: true });
   const sitemapAndIndexStream = new SitemapAndIndexStream({
@@ -52,7 +59,7 @@ export const simpleSitemapAndIndex = async ({
       const sitemapStream = new SitemapStream({
         hostname,
       });
-      const path = `./sitemap-${i}.xml`;
+      const path = nameGenerator(i);
       const writePath = resolve(destinationDir, path + (gzip ? '.gz' : ''));
       if (!publicBasePath.endsWith('/')) {
         publicBasePath += '/';


### PR DESCRIPTION
I have an use case where, google denies to read generated `sitemap-*.xml` files. For no reason at all. 
It does reads, sitemap files with different names. Hence the pull request to generate the sitemap file name dynamically. 