### PR TITLE
Fix invalid XML regex

### DIFF
--- a/lib/sitemap-xml.ts
+++ b/lib/sitemap-xml.ts
@@ -4,7 +4,7 @@ import { IndexTagNames } from './sitemap-index-stream';
 
 const invalidXMLUnicodeRegex =
   // eslint-disable-next-line no-control-regex
-  /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u0084\u0086-\u009F\uD800-\uDFFF\uFDD0-\uFDDF\u{1FFFE}-\u{1FFFF}\u{2FFFE}-\u{2FFFF}\u{3FFFE}-\u{3FFFF}\u{4FFFE}-\u{4FFFF}\u{5FFFE}-\u{5FFFF}\u{6FFFE}-\u{6FFFF}\u{7FFFE}-\u{7FFFF}\u{8FFFE}-\u{8FFFF}\u{9FFFE}-\u{9FFFF}\u{AFFFE}-\u{AFFFF}\u{BFFFE}-\u{BFFFF}\u{CFFFE}-\u{CFFFF}\u{DFFFE}-\u{DFFFF}\u{EFFFE}-\u{EFFFF}\u{FFFFE}-\u{FFFFF}\u{10FFFE}-\u{10FFFF}]/gu;
+  /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u0084\u0086-\u009F\uD800-\uDFFF\p{NChar}]/gu;
 const amp = /&/g;
 const lt = /</g;
 const apos = /'/g;


### PR DESCRIPTION
Use the NChar character class to specify Unicode noncharacters rather than specify the ranges manually. This fixes a typo in the first range (should end with \uFDEF not \uFDDF).

See [here](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=[:NChar:]).