### PR TITLE
Move @types to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,8 +147,6 @@
     }
   },
   "dependencies": {
-    "@types/node": "^17.0.5",
-    "@types/sax": "^1.2.1",
     "arg": "^5.0.0",
     "sax": "^1.2.4"
   },
@@ -162,6 +160,8 @@
     "@babel/preset-typescript": "^7.13.0",
     "@types/jest": "^27.4.0",
     "@types/memorystream": "^0.3.0",
+    "@types/node": "^17.0.5",
+    "@types/sax": "^1.2.1",
     "@typescript-eslint/eslint-plugin": "^5.8.1",
     "@typescript-eslint/parser": "^5.8.1",
     "babel-eslint": "^10.1.0",


### PR DESCRIPTION
There is no reason to make @types as dependency of this lib since the lib is published as JS.

In dev env, it will be installed but in prod env, there is no need for types at all.