### PR TITLE
fix #464: backport xsi:schemaLocation support from 8.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,41 @@ if (validators['video:rating'].test('4.5')) {
 }
 ```
 
+## 8.0.2 - Bug Fix Release
+
+### Bug Fixes
+
+- **fix #464**: Support `xsi:schemaLocation` in custom namespaces - thanks @dzakki
+  - Extended custom namespace validation to accept namespace-qualified attributes (like `xsi:schemaLocation`) in addition to `xmlns` declarations
+  - The validation regex now matches both `xmlns:prefix="uri"` and `prefix:attribute="value"` patterns
+  - Enables proper W3C schema validation while maintaining security validation for malicious content
+  - Added comprehensive tests including security regression tests
+
+### Example Usage
+
+The following now works correctly (as documented in README):
+
+```javascript
+const sms = new SitemapStream({
+  xmlns: {
+    custom: [
+      'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"',
+      'xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"'
+    ]
+  }
+});
+```
+
+### Testing
+
+- ✅ All existing tests passing
+- ✅ 8 new tests added covering positive and security scenarios
+- ✅ 100% backward compatible with 8.0.1
+
+### Files Changed
+
+2 files changed: 144 insertions, 5 deletions
+
 ## 8.0.1 - Security Patch Release
 
 **SECURITY FIXES** - This release backports comprehensive security patches from 9.0.0 to 8.0.x

--- a/lib/sitemap-stream.ts
+++ b/lib/sitemap-stream.ts
@@ -48,8 +48,9 @@ function validateCustomNamespaces(custom: string[]): void {
     );
   }
 
-  // Basic format validation for xmlns declarations
-  const xmlnsPattern = /^xmlns:[a-zA-Z_][\w.-]*="[^"<>]*"$/;
+  // Basic format validation for xmlns declarations and namespace-qualified attributes
+  // Supports both xmlns:prefix="uri" and prefix:attribute="value" (e.g., xsi:schemaLocation)
+  const xmlAttributePattern = /^[a-zA-Z_][\w.-]*:[a-zA-Z_][\w.-]*="[^"<>]*"$/;
 
   for (const ns of custom) {
     if (typeof ns !== 'string' || ns.length === 0) {
@@ -75,10 +76,10 @@ function validateCustomNamespaces(custom: string[]): void {
       );
     }
 
-    // Check format matches xmlns declaration
-    if (!xmlnsPattern.test(ns)) {
+    // Check format matches xmlns declaration or namespace-qualified attribute
+    if (!xmlAttributePattern.test(ns)) {
       throw new Error(
-        `Invalid namespace format (must be xmlns:prefix="uri"): ${ns.substring(0, 50)}`
+        `Invalid namespace format (must be prefix:name="value", e.g., xmlns:prefix="uri" or xsi:schemaLocation="..."): ${ns.substring(0, 50)}`
       );
     }
   }


### PR DESCRIPTION
## Summary

Backports the bug fix from 8.0.2 that enables namespace-qualified attributes like `xsi:schemaLocation` in custom namespaces.

The 8.0.2 fix was originally applied to the 8.0.x maintenance branch but never merged to master. This PR brings that fix forward to 9.0.0.

## Issue

Fixes #464

The README documented support for `xsi:schemaLocation` attributes in custom namespaces, but the validation code rejected them. This created a discrepancy between documentation and actual functionality.

## Changes

### Code Changes
- **[lib/sitemap-stream.ts](lib/sitemap-stream.ts)**: Updated regex pattern to accept both `xmlns:prefix="uri"` declarations AND `prefix:attribute="value"` namespace-qualified attributes
- **[tests/sitemap-stream.test.ts](tests/sitemap-stream.test.ts)**: Added 8 comprehensive tests covering:
  - `xsi:schemaLocation` support (README example)
  - Other namespace-qualified attributes
  - Security validation (rejecting script tags, javascript: URLs, data: URLs, invalid formats)

### Documentation Changes
- **[CHANGELOG.md](CHANGELOG.md)**: Added 8.0.2 section documenting the fix between 9.0.0 and 8.0.1 entries

## Testing

- ✅ All 364 tests pass
- ✅ Coverage maintained above thresholds (90%+ statements, functions, lines; 80%+ branches)
- ✅ XML schema validation with xmllint passes
- ✅ Lint and build successful

## Compatibility

- **100% backward compatible** - relaxes validation without breaking existing usage
- All existing valid inputs continue to work
- Only enables previously-rejected namespace-qualified attributes

## Example

The following now works correctly (as documented in README):

```javascript
const sms = new SitemapStream({
  xmlns: {
    custom: [
      'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"',
      'xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"'
    ]
  }
});
```

## Original Fix

Original fix commit: `eeb032d` (8.0.2-release branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)