### PR TITLE
fix: support CDATA sections in <loc> and <image:loc> tags (fixes #445)

### DIFF
--- a/lib/sitemap-parser.ts
+++ b/lib/sitemap-parser.ts
@@ -600,6 +600,27 @@ export class XMLToSitemapItemStream extends Transform {
 
     this.saxStream.on('cdata', (text): void => {
       switch (currentTag) {
+        case TagNames.loc:
+          // Validate URL
+          if (text.length > LIMITS.MAX_URL_LENGTH) {
+            this.logger(
+              'warn',
+              `URL exceeds max length of ${LIMITS.MAX_URL_LENGTH}: ${text.substring(0, 100)}...`
+            );
+            this.err(`URL exceeds max length of ${LIMITS.MAX_URL_LENGTH}`);
+          } else if (!LIMITS.URL_PROTOCOL_REGEX.test(text)) {
+            this.logger(
+              'warn',
+              `URL must start with http:// or https://: ${text}`
+            );
+            this.err(`URL must start with http:// or https://: ${text}`);
+          } else {
+            currentItem.url = text;
+          }
+          break;
+        case TagNames['image:loc']:
+          currentImage.url = text;
+          break;
         case TagNames['video:title']:
           if (
             currentVideo.title.length + text.length <=

--- a/tests/sitemap-parser.test.ts
+++ b/tests/sitemap-parser.test.ts
@@ -148,6 +148,60 @@ describe('XMLToSitemapItemStream', () => {
     );
     expect(sitemap).toEqual(normalizedSample.urls);
   });
+
+  it('parses CDATA in <loc> tags (issue #445)', async () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" ?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc><![CDATA[https://example.com/page1]]></loc>
+  </url>
+</urlset>`;
+    const results = await parseSitemap(Readable.from(xml));
+    expect(results).toHaveLength(1);
+    expect(results[0].url).toBe('https://example.com/page1');
+  });
+
+  it('parses CDATA in <image:loc> tags (issue #445)', async () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" ?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+  <url>
+    <loc>https://example.com/page</loc>
+    <image:image>
+      <image:loc><![CDATA[https://example.com/image.jpg]]></image:loc>
+    </image:image>
+  </url>
+</urlset>`;
+    const results = await parseSitemap(Readable.from(xml));
+    expect(results).toHaveLength(1);
+    expect(results[0].url).toBe('https://example.com/page');
+    expect(results[0].img).toHaveLength(1);
+    expect(results[0].img[0].url).toBe('https://example.com/image.jpg');
+  });
+
+  it('validates URLs in CDATA sections', async () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" ?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc><![CDATA[invalid-url]]></loc>
+  </url>
+</urlset>`;
+    // With THROW error level, invalid URLs should cause errors
+    const stream = new XMLToSitemapItemStream({ level: ErrorLevel.THROW });
+    const promise = pipeline(
+      Readable.from(xml),
+      stream,
+      new Writable({
+        objectMode: true,
+        write(chunk, a, cb): void {
+          cb();
+        },
+      })
+    );
+    await expect(promise).rejects.toThrow(
+      'URL must start with http:// or https://'
+    );
+  });
 });
 
 describe('ObjectStreamToJSON', () => {


### PR DESCRIPTION
## Summary

Adds support for parsing CDATA sections in `<loc>` and `<image:loc>` tags, fixing issue #445.

## Problem

The sitemap parser was throwing "unhandled cdata for tag: loc" warnings when parsing third-party sitemaps that use CDATA sections in location tags. While the parser already supported CDATA in other tags (video:title, news:name, image:caption), it was missing handlers for the main location tags, causing URLs to be parsed as empty strings.

## Solution

Added CDATA handlers for `<loc>` and `<image:loc>` tags that mirror the same validation logic used for regular text content. This aligns with:
- The existing implementation in sitemap-index-parser.ts (which already supports CDATA in loc tags)
- W3C XML specification (CDATA sections are valid in any element's text content)
- Real-world usage (third-party sitemaps use CDATA as a valid alternative to entity-escaping)

## Changes

- Added CDATA handler for `<loc>` tags with URL validation (length, protocol checks)
- Added CDATA handler for `<image:loc>` tags
- Added comprehensive tests for CDATA support in location tags
- Added test for URL validation in CDATA sections

## Testing

✅ All 372 tests pass
✅ Code coverage maintained at 90%+ (90.4% statements, 84.06% branches)
✅ Validated with the exact XML example from issue #445
✅ Verified URL validation works correctly for CDATA content

## Validation Process

1. Created test files with CDATA in `<loc>` and `<image:loc>` tags
2. Confirmed the bug: parser logged warnings and returned empty URLs
3. Applied fix and verified URLs are now correctly extracted
4. Added tests to prevent regression

Fixes #445