### PR TITLE
fix: security patch 9.0.1 — 3 high and 2 medium severity vulnerabilities (BB-01–BB-05)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 9.0.1 — Security Patch
+
+- **BB-01**: Fix XML injection via unescaped `xslUrl` in stylesheet processing instruction — special characters (`&`, `"`, `<`, `>`) in the XSL URL are now escaped before being interpolated into the `<?xml-stylesheet?>` processing instruction
+- **BB-02**: Enforce 50,000 URL hard limit in `XMLToSitemapItemStream` — the parser now stops emitting items and emits an error when the limit is exceeded, rather than merely logging a warning
+- **BB-03**: Cap parser error array at 100 entries to prevent memory DoS — `XMLToSitemapItemStream` now tracks a separate `errorCount` and stops appending to the `errors` array beyond `LIMITS.MAX_PARSER_ERRORS`
+- **BB-04**: Reject absolute `destinationDir` paths in `simpleSitemapAndIndex` to prevent arbitrary file writes — passing an absolute path (e.g. `/tmp/sitemaps`) now throws immediately with a descriptive error
+- **BB-05**: `parseSitemapIndex` now destroys source and parser streams immediately when the `maxEntries` limit is exceeded, preventing unbounded memory consumption from large sitemap index files
+
 ## 9.0.0 - 2025-11-01
 
 This major release modernizes the package with ESM-first architecture, drops support for Node.js < 20, and includes comprehensive security and robustness improvements.

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -58,6 +58,10 @@ export const LIMITS = {
   // Custom namespace limits to prevent DoS
   MAX_CUSTOM_NAMESPACES: 20,
   MAX_NAMESPACE_LENGTH: 512,
+
+  // Cap on stored parser errors to prevent memory DoS (BB-03)
+  // Errors beyond this limit are counted in errorCount but not retained as objects
+  MAX_PARSER_ERRORS: 100,
 } as const;
 
 /**

--- a/lib/sitemap-index-parser.ts
+++ b/lib/sitemap-index-parser.ts
@@ -222,25 +222,48 @@ export async function parseSitemapIndex(
 ): Promise<IndexItem[]> {
   const urls: IndexItem[] = [];
   return new Promise((resolve, reject): void => {
+    let settled = false;
+
+    const parser = new XMLToSitemapIndexStream();
+
+    // Handle source stream errors (prevents unhandled error events on xml)
+    xml.on('error', (error: Error): void => {
+      if (!settled) {
+        settled = true;
+        reject(error);
+      }
+    });
+
     xml
-      .pipe(new XMLToSitemapIndexStream())
+      .pipe(parser)
       .on('data', (smi: IndexItem) => {
+        if (settled) return;
         // Security: Prevent memory exhaustion by limiting number of entries
         if (urls.length >= maxEntries) {
+          settled = true;
           reject(
             new Error(
               `Sitemap index exceeds maximum allowed entries (${maxEntries})`
             )
           );
+          // Immediately destroy both streams to stop further processing (BB-05)
+          parser.destroy();
+          xml.destroy();
           return;
         }
         urls.push(smi);
       })
       .on('end', (): void => {
-        resolve(urls);
+        if (!settled) {
+          settled = true;
+          resolve(urls);
+        }
       })
       .on('error', (error: Error): void => {
-        reject(error);
+        if (!settled) {
+          settled = true;
+          reject(error);
+        }
       });
   });
 }

--- a/lib/sitemap-index-stream.ts
+++ b/lib/sitemap-index-stream.ts
@@ -9,7 +9,7 @@ import {
 import { SitemapStream, stylesheetInclude } from './sitemap-stream.js';
 import { element, otag, ctag } from './sitemap-xml.js';
 import { LIMITS, DEFAULT_SITEMAP_ITEM_LIMIT } from './constants.js';
-import { validateURL } from './validation.js';
+import { validateURL, validateXSLUrl } from './validation.js';
 
 // Re-export IndexTagNames for backward compatibility
 export { IndexTagNames };
@@ -77,6 +77,9 @@ export class SitemapIndexStream extends Transform {
     this.hasHeadOutput = false;
     this.lastmodDateOnly = opts.lastmodDateOnly || false;
     this.level = opts.level ?? ErrorLevel.WARN;
+    if (opts.xslUrl !== undefined) {
+      validateXSLUrl(opts.xslUrl);
+    }
     this.xslUrl = opts.xslUrl;
   }
 

--- a/lib/sitemap-parser.ts
+++ b/lib/sitemap-parser.ts
@@ -93,10 +93,13 @@ export class XMLToSitemapItemStream extends Transform {
   level: ErrorLevel;
   logger: Logger;
   /**
-   * All errors encountered during parsing.
-   * Each validation failure is captured here for comprehensive error reporting.
+   * Errors encountered during parsing, capped at LIMITS.MAX_PARSER_ERRORS entries
+   * to prevent memory DoS from malformed XML (BB-03).
+   * Use errorCount for the total number of errors regardless of the cap.
    */
   errors: Error[];
+  /** Total number of errors seen, including those beyond the stored cap. */
+  errorCount: number;
   saxStream: SAXStream;
   urlCount: number;
 
@@ -104,6 +107,7 @@ export class XMLToSitemapItemStream extends Transform {
     opts.objectMode = true;
     super(opts);
     this.errors = [];
+    this.errorCount = 0;
     this.urlCount = 0;
     this.saxStream = sax.createStream(true, {
       xmlns: true,
@@ -954,8 +958,10 @@ export class XMLToSitemapItemStream extends Transform {
   }
 
   private err(msg: string) {
-    const error = new Error(msg);
-    this.errors.push(error);
+    this.errorCount++;
+    if (this.errors.length < LIMITS.MAX_PARSER_ERRORS) {
+      this.errors.push(new Error(msg));
+    }
   }
 }
 

--- a/lib/sitemap-parser.ts
+++ b/lib/sitemap-parser.ts
@@ -866,7 +866,8 @@ export class XMLToSitemapItemStream extends Transform {
             this.err(
               `Sitemap exceeds maximum of ${LIMITS.MAX_URL_ENTRIES} URLs`
             );
-            // Still push the item but log the error
+            currentItem = tagTemplate();
+            break;
           }
           this.push(currentItem);
           currentItem = tagTemplate();

--- a/lib/sitemap-stream.ts
+++ b/lib/sitemap-stream.ts
@@ -18,7 +18,12 @@ import { LIMITS } from './constants.js';
 
 const xmlDec = '<?xml version="1.0" encoding="UTF-8"?>';
 export const stylesheetInclude = (url: string): string => {
-  return `<?xml-stylesheet type="text/xsl" href="${url}"?>`;
+  const safe = url
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+  return `<?xml-stylesheet type="text/xsl" href="${safe}"?>`;
 };
 const urlsetTagStart =
   '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"';

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -45,6 +45,7 @@ import {
   ErrorHandler,
 } from './types.js';
 import { LIMITS } from './constants.js';
+import { isAbsolute } from 'node:path';
 
 /**
  * Validator regular expressions for various sitemap fields
@@ -161,6 +162,15 @@ export function validateURL(url: string, paramName: string): void {
 export function validatePath(path: string, paramName: string): void {
   if (!path || typeof path !== 'string') {
     throw new InvalidPathError(path, `${paramName} must be a non-empty string`);
+  }
+
+  // Reject absolute paths to prevent arbitrary write location when caller input
+  // reaches destinationDir (BB-04)
+  if (isAbsolute(path)) {
+    throw new InvalidPathError(
+      path,
+      `${paramName} must be a relative path (absolute paths are not allowed)`
+    );
   }
 
   // Check for path traversal sequences - must check before and after normalization

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -365,6 +365,15 @@ export function validateXSLUrl(xslUrl: string): void {
       );
     }
   }
+
+  // Reject unencoded XML special characters — these must be percent-encoded in
+  // valid URLs and could break out of XML attribute context if left raw.
+  if (xslUrl.includes('"') || xslUrl.includes('<') || xslUrl.includes('>')) {
+    throw new InvalidXSLUrlError(
+      xslUrl,
+      'contains unencoded XML special characters (" < >); percent-encode them in the URL'
+    );
+  }
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sitemap",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sitemap",
-      "version": "9.0.0",
+      "version": "9.0.1",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^24.9.2",
@@ -573,9 +573,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -654,7 +654,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -845,7 +847,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.1",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2052,7 +2056,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3059,7 +3065,9 @@
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4575,7 +4583,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4923,11 +4933,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -5425,9 +5437,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -6228,7 +6240,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sitemap",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Sitemap-generating lib/cli",
   "keywords": [
     "sitemap",

--- a/tests/sitemap-index-security.test.ts
+++ b/tests/sitemap-index-security.test.ts
@@ -451,6 +451,42 @@ describe('Sitemap Index Security', () => {
         await parseSitemapIndex(readable, 2);
       }).rejects.toThrow(/exceeds maximum allowed entries \(2\)/);
     });
+
+    it('immediately destroys streams when maxEntries is exceeded (BB-05)', async () => {
+      let i = 0;
+      const max = 100000;
+      const src = new Readable({
+        read() {
+          if (i === 0) {
+            this.push(
+              '<?xml version="1.0"?><sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+            );
+            i++;
+            return;
+          }
+          if (i <= max) {
+            this.push(`<sitemap><loc>https://e.com/${i}.xml</loc></sitemap>`);
+            i++;
+            return;
+          }
+          if (i === max + 1) {
+            this.push('</sitemapindex>');
+            i++;
+            return;
+          }
+          this.push(null);
+        },
+      });
+
+      await expect(parseSitemapIndex(src, 1)).rejects.toThrow(
+        /exceeds maximum allowed entries/
+      );
+
+      // Source stream must be destroyed immediately (not after full document consumption)
+      expect(src.destroyed).toBe(true);
+      // Counter must be far below max — early teardown, not full traversal
+      expect(i).toBeLessThan(max / 2);
+    });
   });
 
   describe('CDATA Handling', () => {

--- a/tests/sitemap-index-security.test.ts
+++ b/tests/sitemap-index-security.test.ts
@@ -6,7 +6,9 @@ import {
   XMLToSitemapIndexStream,
 } from '../lib/sitemap-index-parser.js';
 import { SitemapIndexStream } from '../lib/sitemap-index-stream.js';
+import { streamToPromise } from '../lib/sitemap-stream.js';
 import { ErrorLevel, IndexItem } from '../lib/types.js';
+import { InvalidXSLUrlError } from '../lib/errors.js';
 
 const pipeline = promisify(pipe);
 
@@ -517,6 +519,82 @@ describe('Sitemap Index Security', () => {
       // Should only get valid URL, invalid one silently skipped
       expect(items).toHaveLength(1);
       expect(items[0].url).toBe('https://example.com/sitemap.xml');
+    });
+  });
+
+  describe('xslUrl validation in SitemapIndexStream', () => {
+    it('should accept valid https xslUrl', () => {
+      expect(
+        () =>
+          new SitemapIndexStream({ xslUrl: 'https://example.com/style.xsl' })
+      ).not.toThrow();
+    });
+
+    it('should accept valid http xslUrl', () => {
+      expect(
+        () => new SitemapIndexStream({ xslUrl: 'http://example.com/style.xsl' })
+      ).not.toThrow();
+    });
+
+    it('should reject quote-breakout XML injection payload', () => {
+      expect(
+        () =>
+          new SitemapIndexStream({
+            xslUrl: 'https://attacker.test/x.xsl"?><evil>pwned</evil><!--',
+          })
+      ).toThrow(InvalidXSLUrlError);
+    });
+
+    it('should reject ftp: protocol in xslUrl', () => {
+      expect(
+        () => new SitemapIndexStream({ xslUrl: 'ftp://example.com/style.xsl' })
+      ).toThrow(InvalidXSLUrlError);
+    });
+
+    it('should reject javascript: protocol in xslUrl', () => {
+      expect(
+        () => new SitemapIndexStream({ xslUrl: 'javascript:alert(1)' })
+      ).toThrow(InvalidXSLUrlError);
+    });
+
+    it('should reject data: protocol in xslUrl', () => {
+      expect(
+        () =>
+          new SitemapIndexStream({
+            xslUrl: 'data:text/html,<script>alert(1)</script>',
+          })
+      ).toThrow(InvalidXSLUrlError);
+    });
+
+    it('should reject file: protocol in xslUrl', () => {
+      expect(
+        () => new SitemapIndexStream({ xslUrl: 'file:///etc/passwd' })
+      ).toThrow(InvalidXSLUrlError);
+    });
+
+    it('should reject empty xslUrl', () => {
+      expect(() => new SitemapIndexStream({ xslUrl: '' })).toThrow(
+        InvalidXSLUrlError
+      );
+    });
+
+    it('should reject xslUrl exceeding max length', () => {
+      const longUrl = 'https://' + 'a'.repeat(2048) + '.com/style.xsl';
+      expect(() => new SitemapIndexStream({ xslUrl: longUrl })).toThrow(
+        InvalidXSLUrlError
+      );
+    });
+
+    it('should include xslUrl in output when valid', async () => {
+      const stream = new SitemapIndexStream({
+        xslUrl: 'https://example.com/style.xsl',
+      });
+      stream.write('https://example.com/sitemap.xml');
+      stream.end();
+      const result = (await streamToPromise(stream)).toString();
+      expect(result).toContain(
+        '<?xml-stylesheet type="text/xsl" href="https://example.com/style.xsl"?>'
+      );
     });
   });
 

--- a/tests/sitemap-parser-security.test.ts
+++ b/tests/sitemap-parser-security.test.ts
@@ -3,6 +3,7 @@ import { promisify } from 'node:util';
 import { pipeline as pipe } from 'node:stream';
 import { XMLToSitemapItemStream } from '../lib/sitemap-parser.js';
 import { SitemapItem } from '../lib/types.js';
+import { LIMITS } from '../lib/constants.js';
 
 const pipeline = promisify(pipe);
 
@@ -526,6 +527,7 @@ describe('sitemap-parser security tests', () => {
         'error',
         expect.stringContaining('exceeds maximum of 50000 URLs')
       );
+      expect(sitemap.length).toBeLessThanOrEqual(LIMITS.MAX_URL_ENTRIES);
     }, 60000); // Longer timeout for this test
   });
 

--- a/tests/sitemap-parser-security.test.ts
+++ b/tests/sitemap-parser-security.test.ts
@@ -1090,4 +1090,32 @@ describe('sitemap-parser security tests', () => {
       expect(video['gallery_loc:title']).toBe('Gallery');
     });
   });
+
+  describe('memory DoS prevention', () => {
+    it('caps stored errors to prevent memory DoS (BB-03)', async () => {
+      const n = 5000;
+      const junk = Array.from(
+        { length: n },
+        (_, i) => `<evil${i}>x</evil${i}>`
+      ).join('');
+      const xml = `<?xml version="1.0"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${junk}</urlset>`;
+
+      const parser = new XMLToSitemapItemStream({ logger: false });
+      await pipeline(
+        Readable.from([xml]),
+        parser,
+        new Writable({
+          objectMode: true,
+          write(_chunk, _enc, cb) {
+            cb();
+          },
+        })
+      );
+
+      expect(parser.errors.length).toBeLessThanOrEqual(
+        LIMITS.MAX_PARSER_ERRORS
+      );
+      expect(parser.errorCount).toBeGreaterThan(LIMITS.MAX_PARSER_ERRORS);
+    });
+  });
 });

--- a/tests/sitemap-simple-security.test.ts
+++ b/tests/sitemap-simple-security.test.ts
@@ -1,36 +1,18 @@
 import { simpleSitemapAndIndex, EnumChangefreq } from '../index.js';
-import { tmpdir } from 'node:os';
-import { resolve } from 'node:path';
-import { existsSync, unlinkSync } from 'node:fs';
-
-function removeFilesArray(files: string[]): void {
-  if (files && files.length) {
-    files.forEach(function (file: string) {
-      if (existsSync(file)) {
-        unlinkSync(file);
-      }
-    });
-  }
-}
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 describe('simpleSitemapAndIndex - Security Tests', () => {
   let targetFolder: string;
 
   beforeEach(() => {
-    targetFolder = tmpdir();
-    removeFilesArray([
-      resolve(targetFolder, `./sitemap-index.xml.gz`),
-      resolve(targetFolder, `./sitemap-0.xml.gz`),
-      resolve(targetFolder, `./sitemap-1.xml.gz`),
-    ]);
+    targetFolder = mkdtempSync('sitemap-sec-test-');
   });
 
   afterEach(() => {
-    removeFilesArray([
-      resolve(targetFolder, `./sitemap-index.xml.gz`),
-      resolve(targetFolder, `./sitemap-0.xml.gz`),
-      resolve(targetFolder, `./sitemap-1.xml.gz`),
-    ]);
+    if (targetFolder && existsSync(targetFolder)) {
+      rmSync(targetFolder, { recursive: true, force: true });
+    }
   });
 
   describe('hostname validation', () => {
@@ -101,6 +83,16 @@ describe('simpleSitemapAndIndex - Security Tests', () => {
   });
 
   describe('destinationDir validation', () => {
+    it('throws on absolute destinationDir path', async () => {
+      await expect(
+        simpleSitemapAndIndex({
+          hostname: 'https://example.com',
+          destinationDir: '/tmp/sitemaps',
+          sourceData: ['https://1.example.com/a'],
+        })
+      ).rejects.toThrow(/must be a relative path/);
+    });
+
     it('throws on path traversal with ../', async () => {
       await expect(
         simpleSitemapAndIndex({
@@ -132,7 +124,7 @@ describe('simpleSitemapAndIndex - Security Tests', () => {
     });
 
     it('accepts valid relative paths', async () => {
-      const testDir = resolve(targetFolder, './valid-subdir');
+      const testDir = join(targetFolder, 'valid-subdir');
       await expect(
         simpleSitemapAndIndex({
           hostname: 'https://example.com',
@@ -466,17 +458,19 @@ describe('simpleSitemapAndIndex - Security Tests', () => {
 
   describe('error context in messages', () => {
     it('provides context when mkdir fails', async () => {
-      // Use a path that will fail on permission error (platform-specific)
-      const invalidDir = '/root/nonexistent-' + Date.now();
-      const result = simpleSitemapAndIndex({
-        hostname: 'https://example.com',
-        destinationDir: invalidDir,
-        sourceData: ['https://1.example.com/a'],
-      });
+      // Place a regular file where mkdir expects a directory component so that
+      // mkdir('…/blocker/subdir', {recursive:true}) throws ENOTDIR
+      const blocker = join(targetFolder, 'blocker');
+      writeFileSync(blocker, 'x');
+      const invalidDir = join(targetFolder, 'blocker', 'subdir');
 
-      await expect(result).rejects.toThrow(
-        /Failed to create destination directory/
-      );
+      await expect(
+        simpleSitemapAndIndex({
+          hostname: 'https://example.com',
+          destinationDir: invalidDir,
+          sourceData: ['https://1.example.com/a'],
+        })
+      ).rejects.toThrow(/Failed to create destination directory/);
     });
   });
 });

--- a/tests/sitemap-simple.test.ts
+++ b/tests/sitemap-simple.test.ts
@@ -1,7 +1,6 @@
 import { simpleSitemapAndIndex, streamToPromise } from '../index.js';
-import { tmpdir } from 'node:os';
-import { resolve } from 'node:path';
 import { existsSync, createReadStream, mkdtempSync, rmSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { createGunzip } from 'node:zlib';
 
 describe('simpleSitemapAndIndex', () => {
@@ -9,7 +8,7 @@ describe('simpleSitemapAndIndex', () => {
 
   beforeEach(() => {
     // Create unique temp directory for each test to avoid conflicts
-    targetFolder = mkdtempSync(resolve(tmpdir(), 'sitemap-test-'));
+    targetFolder = mkdtempSync('sitemap-test-');
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

Security patch release fixing five vulnerabilities discovered after 9.0.0 (3 high, 2 medium):

| ID | Severity | Description |
|----|----------|-------------|
| BB-01 | Medium | XML injection via unescaped `xslUrl` in stylesheet processing instruction |
| BB-02 | **High** | Bypass of 50,000 URL hard limit in `XMLToSitemapItemStream` parser |
| BB-03 | **High** | Memory exhaustion via unbounded parser error collection |
| BB-04 | **High** | Arbitrary file writes via absolute `destinationDir` paths in `simpleSitemapAndIndex` |
| BB-05 | Medium | Unbounded memory consumption in `parseSitemapIndex` on `maxEntries` breach |

## Changes

- **BB-01** (`lib/sitemap-stream.ts`, `lib/sitemap-index-stream.ts`, `lib/validation.ts`): XML-escape `&`, `"`, `<`, `>` in XSL URLs before stylesheet PI generation; validate at stream construction
- **BB-02** (`lib/sitemap-parser.ts`): Enforce hard 50K URL limit with error emission instead of just logging a warning
- **BB-03** (`lib/constants.ts`, `lib/sitemap-parser.ts`): Cap error array at `LIMITS.MAX_PARSER_ERRORS` (100); track total error count separately
- **BB-04** (`lib/validation.ts`): Reject absolute paths in `validatePath()` with a descriptive error
- **BB-05** (`lib/sitemap-index-parser.ts`): Immediately destroy source and parser streams when `maxEntries` is exceeded

## Test Plan

- [ ] All existing tests pass (`npm test`)
- [ ] New security tests added for each fix (`tests/sitemap-index-security.test.ts`, `tests/sitemap-parser-security.test.ts`, `tests/sitemap-simple-security.test.ts`)
- [ ] 90%+ code coverage maintained
- [ ] Build succeeds (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)