### PR TITLE
fix: eliminate stream-timing race in mergeStreams test on Node 26

### DIFF
--- a/tests/sitemap-utils.test.ts
+++ b/tests/sitemap-utils.test.ts
@@ -1037,17 +1037,21 @@ describe('utils', () => {
       const in1 = Readable.from(['a', 'b']);
       const in2 = Readable.from(['c', 'd']);
       const memStream = new MemoryStream();
-      const in1Done = finishedP(in1);
-      const in2Done = finishedP(in2);
+      const memDone = finishedP(memStream);
       const mergeStream = mergeStreams([in1, in2]);
+
+      const chunks: Buffer[] = [];
+      memStream.on('data', (chunk) => chunks.push(chunk));
 
       mergeStream.pipe(memStream);
 
-      // Wait for the two inputs to be done being read
-      await Promise.all([in1Done, in2Done]);
+      // Wait for all merged data to be written into memStream and its
+      // readable side to end, rather than assuming that happens within the
+      // same tick as the source streams finishing (that timing isn't
+      // guaranteed across Node versions).
+      await memDone;
 
-      const buff = Buffer.from(memStream.read());
-      const str = buff.toString();
+      const str = Buffer.concat(chunks).toString();
 
       expect(str).toContain('a');
       expect(str).toContain('b');


### PR DESCRIPTION
## Summary

Investigated reports that unit tests fail on Node 24/26. The Node 24 case turned out to be a build-order issue (`tests/cli.test.ts` shells out to `dist/esm/cli.js`, which doesn't exist until `npm run build` is run) — not a real regression, and out of scope for a code fix.

The genuine version-specific failure is on **Node 26** only: `mergeStreams › works without options passed` in [tests/sitemap-utils.test.ts](tests/sitemap-utils.test.ts). Node 26 changed internal stream scheduling so that data flowing through a second `.pipe()` hop can now take multiple event-loop ticks to flush, instead of completing within the same tick. The test assumed all merged bytes would already be synchronously buffered in the downstream `MemoryStream` as soon as the two source `Readable`s finished, then read it with a single synchronous `.read()` call — which only observed the first chunk (`"a"`) under the new scheduling.

I confirmed with a standalone repro that `mergeStreams` in [lib/utils.ts](lib/utils.ts) is not buggy — all data (`a`, `b`, `c`, `d`) is delivered correctly, just spread across a few more ticks on Node 26 than before. So this is a test-synchronization fix, not a library fix.

## Changes

- Rewrote the flaky assertion to collect chunks via a `'data'` listener on the output stream and `await` its `'finished'` event, instead of racing on the source streams' completion timing.

## Test plan

- [x] `npm run test:full` passes on Node 26.2.0 (lint, build, all 385 Jest tests, xmllint schema validation)
- [x] Fixed test verified stable (3x repeat runs, no flakes) on Node 20.19.5, 22.2.0, 24.10.0, and 26.2.0 via nvm
- [x] Reproduced original failure and root-caused it with a standalone script before writing the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)