### PR TITLE
fix: exclude .claude/ from Jest test discovery

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -15,7 +15,9 @@ const config = {
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
-  modulePathIgnorePatterns: ['<rootDir>/dist/'],
+  modulePathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/.claude/'],
+  testPathIgnorePatterns: ['/node_modules/', '<rootDir>/.claude/'],
+  watchPathIgnorePatterns: ['<rootDir>/.claude/'],
   collectCoverage: true,
   collectCoverageFrom: [
     'lib/**/*.ts',


### PR DESCRIPTION
## Summary

After #489 merged, running `npm test` from the repo root (`~/projects/sitemap.js`, as opposed to inside one of the `.claude/worktrees/*` checkouts) reported spurious failures. Jest's default `testPathIgnorePatterns` only excludes `node_modules`, so it was also crawling into `.claude/worktrees/*/tests/*.test.ts` and running the test suites of every sibling worktree checkout alongside the main repo's own tests. Any stale or in-progress bug in one of those other worktrees then showed up as a failure of the main repo's test run — e.g. one worktree still had the pre-#489 flaky `mergeStreams` test, another had an unrelated in-progress failure in `sitemap-index.test.ts`.

## Changes

- `jest.config.cjs`: add `<rootDir>/.claude/` to `testPathIgnorePatterns`, `modulePathIgnorePatterns`, and `watchPathIgnorePatterns` so Jest only ever discovers this checkout's own tests and modules, regardless of what worktrees happen to exist alongside it.

## Test plan

- [x] Reproduced the issue: `npm test` from the repo root picked up and failed on tests under `.claude/worktrees/*`
- [x] Applied the fix and confirmed `npm test` from the repo root only runs this checkout's 15 test suites / 385 tests, all passing
- [x] `npm run test:full` passes on this branch (lint, build, Jest, xmllint schema validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)