### PR TITLE
refactor: collapse parser text/cdata handlers, centralize value checks (9.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 9.1.0
+
+- **CDATA accepted everywhere in the sitemap parser**: `XMLToSitemapItemStream` now treats CDATA sections as ordinary character data in every tag. Previously only the 8 tags from issue #445 (`loc`, `image:loc`, `video:title`, `video:description`, `news:name`, `news:title`, `image:caption`, `image:title`) accepted CDATA; content in any other tag was logged as unhandled. (See `docs/adr/0001-cdata-is-character-data.md`.)
+- **Unified `<loc>` validation**: the sitemap parser now validates `<loc>` values with the same `validateURL` used by the sitemap index parser, adding a URL-parseability check on top of the existing length and protocol checks. A rare malformed URL that passed the old checks but fails `new URL()` is now dropped with a warning. Warn/error messages for invalid `<loc>` values changed to the `Invalid URL in sitemap: …` form.
+- Internal: the parser's duplicated `text`/`cdata` SAX handlers were collapsed into one, and its inline bounds checks (priority, video duration/rating/view count, ISO dates) now delegate to shared guards in `lib/validation.ts`, with the bounds defined once in `LIMITS`.
+
 ## 9.0.1 — Security Patch
 
 - **BB-01**: Fix XML injection via unescaped `xslUrl` in stylesheet processing instruction — special characters (`&`, `"`, `<`, `>`) in the XSL URL are now escaped before being interpolated into the `<?xml-stylesheet?>` processing instruction

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,9 @@
+# sitemap.js
+
+A library and CLI for generating and parsing sitemap XML compliant with the sitemaps.org protocol.
+
+## Language
+
+**Sitemap URL**:
+The address carried by a `<loc>` element — of a page in a sitemap, or of a sitemap file in a sitemap index. Always absolute, http or https, at most 2,048 characters, and parseable as a URL. One definition, applied identically wherever a URL is read or written.
+_Avoid_: loc string, link, location

--- a/docs/adr/0001-cdata-is-character-data.md
+++ b/docs/adr/0001-cdata-is-character-data.md
@@ -1,0 +1,14 @@
+# CDATA is ordinary character data, and a Sitemap URL has one definition
+
+`XMLToSitemapItemStream` used to handle SAX `text` and `cdata` events in two near-identical switch statements, where the `cdata` switch covered only the 8 tags patched for issue #445 — CDATA in any other tag was rejected as "unhandled". When collapsing the duplication (July 2026) we decided that CDATA sections are semantically ordinary character data per the XML spec, so both events route through one `handleCharData` and every tag accepts CDATA; and that `<loc>` is validated at the same strength everywhere via `validateURL` (length, protocol, *and* URL-parseability), matching what the sitemap index parser already did.
+
+## Considered Options
+
+- **Preserve the 8-tag CDATA list** behind a `text | cdata` source flag: zero behavior change, but the special-case list would survive as permanent interface complexity, and the #445 list was an incremental patch rather than a design decision.
+- **Keep the weaker inline `loc` check** (length + protocol only): also zero behavior change, but it would leave two different definitions of "valid sitemap URL" living in `lib/validation.ts` — the scatter the refactor existed to remove.
+
+## Consequences
+
+- Parsing is slightly more permissive (CDATA anywhere) and slightly stricter (a `<loc>` that fails `new URL()` is now dropped with a warning). Both deltas shipped in 9.1.0.
+- Invalid-`loc` warnings changed shape to the wrapped `Invalid URL in sitemap: …` form used by the index parser.
+- `<loc>` keeps assign-last-wins semantics for multi-chunk character data; accumulating chunks and validating at closetag was considered and deliberately deferred.

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -29,6 +29,16 @@ export const LIMITS = {
   MIN_SITEMAP_ITEM_LIMIT: 1,
   MAX_SITEMAP_ITEM_LIMIT: 50000,
 
+  // Priority bounds per sitemaps.org spec
+  MIN_PRIORITY: 0,
+  MAX_PRIORITY: 1,
+
+  // Video value bounds per Google spec
+  MIN_VIDEO_DURATION: 0,
+  MAX_VIDEO_DURATION: 28800, // 8 hours
+  MIN_VIDEO_RATING: 0,
+  MAX_VIDEO_RATING: 5,
+
   // Video field length constraints per Google spec
   MAX_VIDEO_TITLE_LENGTH: 100,
   MAX_VIDEO_DESCRIPTION_LENGTH: 2048,

--- a/lib/sitemap-parser.ts
+++ b/lib/sitemap-parser.ts
@@ -21,6 +21,12 @@ import {
   isAllowDeny,
   isPriceType,
   isResolution,
+  isValidPriority,
+  isValidVideoDuration,
+  isValidVideoRating,
+  isValidVideoViewCount,
+  isValidISODate,
+  validateURL,
 } from './validation.js';
 import { LIMITS } from './constants.js';
 
@@ -175,26 +181,21 @@ export class XMLToSitemapItemStream extends Transform {
       }
     });
 
-    this.saxStream.on('text', (text): void => {
+    // Per ADR 0001, CDATA sections are ordinary character data: both SAX
+    // events route through this one handler.
+    const handleCharData = (text: string): void => {
       switch (currentTag) {
         case 'mobile:mobile':
           break;
         case TagNames.loc:
-          // Validate URL
-          if (text.length > LIMITS.MAX_URL_LENGTH) {
-            this.logger(
-              'warn',
-              `URL exceeds max length of ${LIMITS.MAX_URL_LENGTH}: ${text.substring(0, 100)}...`
-            );
-            this.err(`URL exceeds max length of ${LIMITS.MAX_URL_LENGTH}`);
-          } else if (!LIMITS.URL_PROTOCOL_REGEX.test(text)) {
-            this.logger(
-              'warn',
-              `URL must start with http:// or https://: ${text}`
-            );
-            this.err(`URL must start with http:// or https://: ${text}`);
-          } else {
+          try {
+            validateURL(text, 'Sitemap URL');
             currentItem.url = text;
+          } catch (error) {
+            const errMsg =
+              error instanceof Error ? error.message : String(error);
+            this.logger('warn', 'Invalid URL in sitemap:', errMsg);
+            this.err(`Invalid URL in sitemap: ${errMsg}`);
           }
           break;
         case TagNames.changefreq:
@@ -205,12 +206,7 @@ export class XMLToSitemapItemStream extends Transform {
         case TagNames.priority:
           {
             const priority = parseFloat(text);
-            if (
-              isNaN(priority) ||
-              !isFinite(priority) ||
-              priority < 0 ||
-              priority > 1
-            ) {
+            if (!isValidPriority(priority)) {
               this.logger(
                 'warn',
                 `Invalid priority "${text}" - must be between 0 and 1`
@@ -222,7 +218,7 @@ export class XMLToSitemapItemStream extends Transform {
           }
           break;
         case TagNames.lastmod:
-          if (LIMITS.ISO_DATE_REGEX.test(text)) {
+          if (isValidISODate(text)) {
             currentItem.lastmod = text;
           } else {
             this.logger(
@@ -255,12 +251,7 @@ export class XMLToSitemapItemStream extends Transform {
         case TagNames['video:duration']:
           {
             const duration = parseInt(text, 10);
-            if (
-              isNaN(duration) ||
-              !isFinite(duration) ||
-              duration < 0 ||
-              duration > 28800
-            ) {
+            if (!isValidVideoDuration(duration)) {
               this.logger(
                 'warn',
                 `Invalid video duration "${text}" - must be between 0 and 28800 seconds`
@@ -286,7 +277,7 @@ export class XMLToSitemapItemStream extends Transform {
           }
           break;
         case TagNames['video:publication_date']:
-          if (LIMITS.ISO_DATE_REGEX.test(text)) {
+          if (isValidISODate(text)) {
             currentVideo.publication_date = text;
           } else {
             this.logger(
@@ -308,7 +299,7 @@ export class XMLToSitemapItemStream extends Transform {
         case TagNames['video:view_count']:
           {
             const viewCount = parseInt(text, 10);
-            if (isNaN(viewCount) || !isFinite(viewCount) || viewCount < 0) {
+            if (!isValidVideoViewCount(viewCount)) {
               this.logger(
                 'warn',
                 `Invalid video view_count "${text}" - must be a positive integer`
@@ -331,7 +322,7 @@ export class XMLToSitemapItemStream extends Transform {
           }
           break;
         case TagNames['video:expiration_date']:
-          if (LIMITS.ISO_DATE_REGEX.test(text)) {
+          if (isValidISODate(text)) {
             currentVideo.expiration_date = text;
           } else {
             this.logger(
@@ -353,12 +344,7 @@ export class XMLToSitemapItemStream extends Transform {
         case TagNames['video:rating']:
           {
             const rating = parseFloat(text);
-            if (
-              isNaN(rating) ||
-              !isFinite(rating) ||
-              rating < 0 ||
-              rating > 5
-            ) {
+            if (!isValidVideoRating(rating)) {
               this.logger(
                 'warn',
                 `Invalid video rating "${text}" - must be between 0 and 5`
@@ -419,7 +405,7 @@ export class XMLToSitemapItemStream extends Transform {
           if (!currentItem.news) {
             currentItem.news = newsTemplate();
           }
-          if (LIMITS.ISO_DATE_REGEX.test(text)) {
+          if (isValidISODate(text)) {
             currentItem.news.publication_date = text;
           } else {
             this.logger(
@@ -600,176 +586,10 @@ export class XMLToSitemapItemStream extends Transform {
           this.err(`unhandled text for tag: ${currentTag} '${text}'`);
           break;
       }
-    });
+    };
 
-    this.saxStream.on('cdata', (text): void => {
-      switch (currentTag) {
-        case TagNames.loc:
-          // Validate URL
-          if (text.length > LIMITS.MAX_URL_LENGTH) {
-            this.logger(
-              'warn',
-              `URL exceeds max length of ${LIMITS.MAX_URL_LENGTH}: ${text.substring(0, 100)}...`
-            );
-            this.err(`URL exceeds max length of ${LIMITS.MAX_URL_LENGTH}`);
-          } else if (!LIMITS.URL_PROTOCOL_REGEX.test(text)) {
-            this.logger(
-              'warn',
-              `URL must start with http:// or https://: ${text}`
-            );
-            this.err(`URL must start with http:// or https://: ${text}`);
-          } else {
-            currentItem.url = text;
-          }
-          break;
-        case TagNames['image:loc']:
-          currentImage.url = text;
-          break;
-        case TagNames['video:title']:
-          if (
-            currentVideo.title.length + text.length <=
-            LIMITS.MAX_VIDEO_TITLE_LENGTH
-          ) {
-            currentVideo.title += text;
-          } else {
-            this.logger(
-              'warn',
-              `video title exceeds max length of ${LIMITS.MAX_VIDEO_TITLE_LENGTH}`
-            );
-
-            this.err(
-              `video title exceeds max length of ${LIMITS.MAX_VIDEO_TITLE_LENGTH}`
-            );
-          }
-          break;
-        case TagNames['video:description']:
-          if (
-            currentVideo.description.length + text.length <=
-            LIMITS.MAX_VIDEO_DESCRIPTION_LENGTH
-          ) {
-            currentVideo.description += text;
-          } else {
-            this.logger(
-              'warn',
-              `video description exceeds max length of ${LIMITS.MAX_VIDEO_DESCRIPTION_LENGTH}`
-            );
-
-            this.err(
-              `video description exceeds max length of ${LIMITS.MAX_VIDEO_DESCRIPTION_LENGTH}`
-            );
-          }
-          break;
-        case TagNames['news:name']:
-          if (!currentItem.news) {
-            currentItem.news = newsTemplate();
-          }
-          if (
-            currentItem.news.publication.name.length + text.length <=
-            LIMITS.MAX_NEWS_NAME_LENGTH
-          ) {
-            currentItem.news.publication.name += text;
-          } else {
-            this.logger(
-              'warn',
-              `news name exceeds max length of ${LIMITS.MAX_NEWS_NAME_LENGTH}`
-            );
-
-            this.err(
-              `news name exceeds max length of ${LIMITS.MAX_NEWS_NAME_LENGTH}`
-            );
-          }
-          break;
-        case TagNames['news:title']:
-          if (!currentItem.news) {
-            currentItem.news = newsTemplate();
-          }
-          if (
-            currentItem.news.title.length + text.length <=
-            LIMITS.MAX_NEWS_TITLE_LENGTH
-          ) {
-            currentItem.news.title += text;
-          } else {
-            this.logger(
-              'warn',
-              `news title exceeds max length of ${LIMITS.MAX_NEWS_TITLE_LENGTH}`
-            );
-
-            this.err(
-              `news title exceeds max length of ${LIMITS.MAX_NEWS_TITLE_LENGTH}`
-            );
-          }
-          break;
-        case TagNames['image:caption']:
-          if (!currentImage.caption) {
-            currentImage.caption =
-              text.length <= LIMITS.MAX_IMAGE_CAPTION_LENGTH
-                ? text
-                : text.substring(0, LIMITS.MAX_IMAGE_CAPTION_LENGTH);
-            if (text.length > LIMITS.MAX_IMAGE_CAPTION_LENGTH) {
-              this.logger(
-                'warn',
-                `image caption exceeds max length of ${LIMITS.MAX_IMAGE_CAPTION_LENGTH}`
-              );
-
-              this.err(
-                `image caption exceeds max length of ${LIMITS.MAX_IMAGE_CAPTION_LENGTH}`
-              );
-            }
-          } else if (
-            currentImage.caption.length + text.length <=
-            LIMITS.MAX_IMAGE_CAPTION_LENGTH
-          ) {
-            currentImage.caption += text;
-          } else {
-            this.logger(
-              'warn',
-              `image caption exceeds max length of ${LIMITS.MAX_IMAGE_CAPTION_LENGTH}`
-            );
-
-            this.err(
-              `image caption exceeds max length of ${LIMITS.MAX_IMAGE_CAPTION_LENGTH}`
-            );
-          }
-          break;
-        case TagNames['image:title']:
-          if (!currentImage.title) {
-            currentImage.title =
-              text.length <= LIMITS.MAX_IMAGE_TITLE_LENGTH
-                ? text
-                : text.substring(0, LIMITS.MAX_IMAGE_TITLE_LENGTH);
-            if (text.length > LIMITS.MAX_IMAGE_TITLE_LENGTH) {
-              this.logger(
-                'warn',
-                `image title exceeds max length of ${LIMITS.MAX_IMAGE_TITLE_LENGTH}`
-              );
-
-              this.err(
-                `image title exceeds max length of ${LIMITS.MAX_IMAGE_TITLE_LENGTH}`
-              );
-            }
-          } else if (
-            currentImage.title.length + text.length <=
-            LIMITS.MAX_IMAGE_TITLE_LENGTH
-          ) {
-            currentImage.title += text;
-          } else {
-            this.logger(
-              'warn',
-              `image title exceeds max length of ${LIMITS.MAX_IMAGE_TITLE_LENGTH}`
-            );
-
-            this.err(
-              `image title exceeds max length of ${LIMITS.MAX_IMAGE_TITLE_LENGTH}`
-            );
-          }
-          break;
-
-        default:
-          this.logger('log', 'unhandled cdata for tag:', currentTag);
-          this.err(`unhandled cdata for tag: ${currentTag}`);
-          break;
-      }
-    });
+    this.saxStream.on('text', handleCharData);
+    this.saxStream.on('cdata', handleCharData);
 
     this.saxStream.on('attribute', (attr): void => {
       switch (currentTag) {

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -96,6 +96,55 @@ export function isValidYesNo(yn: string): yn is EnumYesNo {
 }
 
 /**
+ * Checks that a priority is a finite number within sitemaps.org bounds (0–1)
+ */
+export function isValidPriority(priority: number): boolean {
+  return (
+    isFinite(priority) &&
+    priority >= LIMITS.MIN_PRIORITY &&
+    priority <= LIMITS.MAX_PRIORITY
+  );
+}
+
+/**
+ * Checks that a video duration is a finite number of seconds within Google's
+ * video sitemap bounds (0–28800)
+ */
+export function isValidVideoDuration(duration: number): boolean {
+  return (
+    isFinite(duration) &&
+    duration >= LIMITS.MIN_VIDEO_DURATION &&
+    duration <= LIMITS.MAX_VIDEO_DURATION
+  );
+}
+
+/**
+ * Checks that a video rating is a finite number within Google's video sitemap
+ * bounds (0–5)
+ */
+export function isValidVideoRating(rating: number): boolean {
+  return (
+    isFinite(rating) &&
+    rating >= LIMITS.MIN_VIDEO_RATING &&
+    rating <= LIMITS.MAX_VIDEO_RATING
+  );
+}
+
+/**
+ * Checks that a video view count is a finite, non-negative number
+ */
+export function isValidVideoViewCount(count: number): boolean {
+  return isFinite(count) && count >= 0;
+}
+
+/**
+ * Checks that a date string is in ISO 8601 / W3C format
+ */
+export function isValidISODate(date: string): boolean {
+  return LIMITS.ISO_DATE_REGEX.test(date);
+}
+
+/**
  * Type guard to check if a string is a valid allow/deny value
  */
 export function isAllowDeny(ad: string): ad is EnumAllowDeny {
@@ -452,7 +501,7 @@ export function validateSMIOptions(
   }
 
   if (priority) {
-    if (!(priority >= 0.0 && priority <= 1.0)) {
+    if (!isValidPriority(priority)) {
       errorHandler(new PriorityInvalidError(url, priority), level);
     }
   }
@@ -483,11 +532,11 @@ export function validateSMIOptions(
   if (video) {
     video.forEach((vid): void => {
       if (vid.duration !== undefined) {
-        if (vid.duration < 0 || vid.duration > 28800) {
+        if (!isValidVideoDuration(vid.duration)) {
           errorHandler(new InvalidVideoDuration(url, vid.duration), level);
         }
       }
-      if (vid.rating !== undefined && (vid.rating < 0 || vid.rating > 5)) {
+      if (vid.rating !== undefined && !isValidVideoRating(vid.rating)) {
         errorHandler(new InvalidVideoRating(url, vid.title, vid.rating), level);
       }
 
@@ -512,7 +561,10 @@ export function validateSMIOptions(
         );
       }
 
-      if (vid.view_count !== undefined && vid.view_count < 0) {
+      if (
+        vid.view_count !== undefined &&
+        !isValidVideoViewCount(vid.view_count)
+      ) {
         errorHandler(new InvalidVideoViewCount(url, vid.view_count), level);
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sitemap",
-  "version": "9.0.1",
+  "version": "9.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sitemap",
-      "version": "9.0.1",
+      "version": "9.1.0",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^24.9.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sitemap",
-  "version": "9.0.1",
+  "version": "9.1.0",
   "description": "Sitemap-generating lib/cli",
   "keywords": [
     "sitemap",

--- a/tests/sitemap-parser-security.test.ts
+++ b/tests/sitemap-parser-security.test.ts
@@ -35,7 +35,8 @@ describe('sitemap-parser security tests', () => {
 
       expect(logger).toHaveBeenCalledWith(
         'warn',
-        expect.stringContaining('URL exceeds max length')
+        'Invalid URL in sitemap:',
+        expect.stringContaining('exceeds maximum length')
       );
     });
 
@@ -67,7 +68,8 @@ describe('sitemap-parser security tests', () => {
 
       expect(logger).toHaveBeenCalledWith(
         'warn',
-        expect.stringContaining('must start with http://')
+        'Invalid URL in sitemap:',
+        expect.stringContaining('must use http:// or https:// protocol')
       );
       expect(sitemap[0].url).not.toBe('javascript:alert(1)');
       expect(sitemap[1].url).not.toBe('file:///etc/passwd');
@@ -595,7 +597,7 @@ describe('sitemap-parser security tests', () => {
       expect(parser.errors.length).toBeGreaterThan(1);
       expect(
         parser.errors.some((e) =>
-          e.message.includes('URL must start with http')
+          e.message.includes('must use http:// or https:// protocol')
         )
       ).toBe(true);
 

--- a/tests/sitemap-parser.test.ts
+++ b/tests/sitemap-parser.test.ts
@@ -199,8 +199,51 @@ describe('XMLToSitemapItemStream', () => {
       })
     );
     await expect(promise).rejects.toThrow(
-      'URL must start with http:// or https://'
+      'must use http:// or https:// protocol'
     );
+  });
+
+  it('parses CDATA as ordinary character data in any tag', async () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" ?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+  <url>
+    <loc>https://example.com/page</loc>
+    <priority><![CDATA[0.5]]></priority>
+    <video:video>
+      <video:thumbnail_loc><![CDATA[https://example.com/thumb.jpg]]></video:thumbnail_loc>
+      <video:title>title</video:title>
+      <video:description>description</video:description>
+    </video:video>
+  </url>
+</urlset>`;
+    const results = await parseSitemap(Readable.from(xml));
+    expect(results).toHaveLength(1);
+    expect(results[0].priority).toBe(0.5);
+    expect(results[0].video[0].thumbnail_loc).toBe(
+      'https://example.com/thumb.jpg'
+    );
+  });
+
+  it('rejects loc values that fail URL parsing', async () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" ?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://exa mple.com/page</loc>
+  </url>
+</urlset>`;
+    const stream = new XMLToSitemapItemStream({ level: ErrorLevel.THROW });
+    const promise = pipeline(
+      Readable.from(xml),
+      stream,
+      new Writable({
+        objectMode: true,
+        write(chunk, a, cb): void {
+          cb();
+        },
+      })
+    );
+    await expect(promise).rejects.toThrow('is not a valid URL');
   });
 });
 


### PR DESCRIPTION
## What changed

`XMLToSitemapItemStream` maintained two near-identical SAX switch statements — the `text` handler (~40 tags) and a `cdata` handler covering only the 8 tags patched for issue #445, duplicating ~150 lines verbatim. Both events now route through a single `handleCharData`, and the parser's inline value checks are delegated to shared guards in `lib/validation.ts`.

- **CDATA is now ordinary character data in every tag** (e.g. `<priority><![CDATA[0.5]]></priority>` now parses). Previously anything outside the 8-tag list was logged as "unhandled cdata".
- **`<loc>` is validated with the same `validateURL` the sitemap index parser uses**, adding a URL-parseability check on top of length + protocol. A malformed URL that passed the old inline check but fails `new URL()` is now dropped with a warning.
- New guards `isValidPriority`, `isValidVideoDuration`, `isValidVideoRating`, `isValidVideoViewCount`, `isValidISODate` in `lib/validation.ts`; `validateSMIOptions` runs on the same guards, and the bounds (`0..1`, `0..28800`, `0..5`) now live once in `LIMITS` (`lib/constants.ts`). None of the new guards are added to the public `index.ts` surface.
- Version bumped to 9.1.0 with a changelog entry; decision recorded in `docs/adr/0001-cdata-is-character-data.md`; first entry in a new `CONTEXT.md` glossary ("Sitemap URL").

Net −44 lines (174 insertions, 218 deletions).

## Why

This is the top candidate from an architecture review of the parser hot spots: the twin handlers meant every per-tag change had to be made twice (the "add a field" recipe in CLAUDE.md silently required editing both), and the inlined URL/bounds checks contradicted the repo's "all validation in lib/validation.ts" rule while enforcing a *weaker* `loc` check than the index parser.

## Reviewer notes

- **Behavior deltas** (both documented in CHANGELOG under 9.1.0, hence minor not patch): CDATA parsing is more permissive; `loc` validation is slightly stricter, and invalid-`loc` warnings changed to the `Invalid URL in sitemap: …` form already used by the index parser. Test churn is confined to 4 message assertions.
- Field-level warn messages for everything except `loc` are byte-identical to before — the parser still composes its own messages and only the checks moved.
- Per-field append/truncation semantics and the `errors`/`errorCount` surface are intentionally untouched.
- `<loc>` keeps assign-last-wins for multi-chunk character data; accumulating at closetag was considered and deferred (see the ADR).
- New tests: CDATA in tags beyond the #445 set, and rejection of an unparseable `loc`. The existing `alltags.cdata.xml` fixture still passes, so #445 behavior is intact.
- `npm run test:full` passes (lint, ESM+CJS builds, 387 tests with coverage thresholds, xmllint schema validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)